### PR TITLE
Do not console.debug undefined variable

### DIFF
--- a/coffee/lib/router.coffee
+++ b/coffee/lib/router.coffee
@@ -38,7 +38,7 @@ define ['mediator', 'lib/route'], (mediator, Route) ->
 
     # Route a given URL path manually, return whether a route matched
     route: (path) =>
-      #console.debug 'Router#route', path, params
+      #console.debug 'Router#route', path
       # Remove leading hash or slash
       path = path.replace /^(\/#|\/)/, ''
       for handler in Backbone.history.handlers


### PR DESCRIPTION
Perhaps I'm not the one who uncomment all `console.debug` calls in order to understand Chaplin's internals better.

It fixes annoying js exception:

```
Uncaught ReferenceError: params is not defined
```
