### PR TITLE
updateBodyClasses

### DIFF
--- a/coffee/views/application_view.coffee
+++ b/coffee/views/application_view.coffee
@@ -60,7 +60,7 @@ define ['mediator', 'lib/utils'], (mediator, utils) ->
       body = $(document.body)
       loggedIn = Boolean mediator.user
       body
-        .toggleClass('logged-out', loggedIn)
+        .toggleClass('logged-out', !loggedIn)
         .toggleClass('logged-in', loggedIn)
 
     # Fallback content


### PR DESCRIPTION
The jQuery `toggleClass` method in `updateBodyClasses` never adds the `logged-out` class to `body` due to an incorrect boolean.
