### PR TITLE
Change template syntax

### DIFF
--- a/coffee/views/compact_like_view.coffee
+++ b/coffee/views/compact_like_view.coffee
@@ -4,7 +4,7 @@ define ['views/view', 'text!templates/compact_like.hbs'], (View, template) ->
   class CompactLikeView extends View
     # This is a workaround.
     # In the end you might want to used precompiled templates.
-    @template = template
+    template: template
 
     tagName: 'li'
     className: 'like'

--- a/coffee/views/full_like_view.coffee
+++ b/coffee/views/full_like_view.coffee
@@ -6,7 +6,7 @@ define [
   class FullLikeView extends View
     # This is a workaround.
     # In the end you might want to used precompiled templates.
-    @template = template
+    template: template
 
     id: 'like'
     containerSelector: '#content-container'

--- a/coffee/views/likes_view.coffee
+++ b/coffee/views/likes_view.coffee
@@ -7,7 +7,7 @@ define [
   class LikesView extends CollectionView
     # This is a workaround.
     # In the end you might want to used precompiled templates.
-    @template: template
+    template: template
 
     tagName: 'div' # This is not directly a list but contains a list
     id: 'likes'

--- a/coffee/views/login_view.coffee
+++ b/coffee/views/login_view.coffee
@@ -6,7 +6,7 @@ define [
   class LoginView extends View
     # This is a workaround.
     # In the end you might want to used precompiled templates.
-    @template = template
+    template: template
 
     id: 'login'
     containerSelector: '#sidebar-container'

--- a/coffee/views/navigation_view.coffee
+++ b/coffee/views/navigation_view.coffee
@@ -4,7 +4,7 @@ define ['views/view', 'text!templates/navigation.hbs'], (View, template) ->
   class NavigationView extends View
     # This is a workaround.
     # In the end you might want to used precompiled templates.
-    @template: template
+    template: template
 
     id: 'navigation'
     containerSelector: '#navigation-container'

--- a/coffee/views/post_view.coffee
+++ b/coffee/views/post_view.coffee
@@ -4,7 +4,7 @@ define ['views/view', 'text!templates/post.hbs'], (View, template) ->
   class PostView extends View
     # This is a workaround.
     # In the end you might want to used precompiled templates.
-    @template = template
+    template: template
 
     tagName: 'li'
     className: 'post'

--- a/coffee/views/posts_view.coffee
+++ b/coffee/views/posts_view.coffee
@@ -8,7 +8,7 @@ define [
 
     # This is a workaround.
     # In the end you might want to used precompiled templates.
-    @template: template
+    template: template
 
     tagName: 'div' # This is not directly a list but contains a list
     id: 'posts'

--- a/coffee/views/sidebar_view.coffee
+++ b/coffee/views/sidebar_view.coffee
@@ -7,7 +7,7 @@ define [
 
     # This is a workaround.
     # In the end you might want to used precompiled templates.
-    @template = template
+    template: template
 
     id: 'sidebar'
     containerSelector: '#sidebar-container'

--- a/coffee/views/view.coffee
+++ b/coffee/views/view.coffee
@@ -234,13 +234,13 @@ define [
       # on the client-side and store it on the view constructor as a
       # static property.
 
-      template = @constructor.template
+      template = @template
       #console.debug "\ttemplate: #{typeof template}"
 
       if typeof template is 'string'
         template = Handlebars.compile template
         # Save compiled template
-        @constructor.template = template
+        @template = template
 
       if typeof template is 'function'
 

--- a/js/views/compact_like_view.js
+++ b/js/views/compact_like_view.js
@@ -12,7 +12,7 @@ define(['views/view', 'text!templates/compact_like.hbs'], function(View, templat
       CompactLikeView.__super__.constructor.apply(this, arguments);
     }
 
-    CompactLikeView.template = template;
+    CompactLikeView.prototype.template = template;
 
     CompactLikeView.prototype.tagName = 'li';
 

--- a/js/views/full_like_view.js
+++ b/js/views/full_like_view.js
@@ -12,7 +12,7 @@ define(['mediator', 'views/view', 'text!templates/full_like.hbs'], function(medi
       FullLikeView.__super__.constructor.apply(this, arguments);
     }
 
-    FullLikeView.template = template;
+    FullLikeView.prototype.template = template;
 
     FullLikeView.prototype.id = 'like';
 

--- a/js/views/likes_view.js
+++ b/js/views/likes_view.js
@@ -12,7 +12,7 @@ define(['mediator', 'views/collection_view', 'views/compact_like_view', 'text!te
       LikesView.__super__.constructor.apply(this, arguments);
     }
 
-    LikesView.template = template;
+    LikesView.prototype.template = template;
 
     LikesView.prototype.tagName = 'div';
 

--- a/js/views/login_view.js
+++ b/js/views/login_view.js
@@ -12,7 +12,7 @@ define(['mediator', 'lib/utils', 'views/view', 'text!templates/login.hbs'], func
       LoginView.__super__.constructor.apply(this, arguments);
     }
 
-    LoginView.template = template;
+    LoginView.prototype.template = template;
 
     LoginView.prototype.id = 'login';
 

--- a/js/views/navigation_view.js
+++ b/js/views/navigation_view.js
@@ -12,7 +12,7 @@ define(['views/view', 'text!templates/navigation.hbs'], function(View, template)
       NavigationView.__super__.constructor.apply(this, arguments);
     }
 
-    NavigationView.template = template;
+    NavigationView.prototype.template = template;
 
     NavigationView.prototype.id = 'navigation';
 

--- a/js/views/post_view.js
+++ b/js/views/post_view.js
@@ -12,7 +12,7 @@ define(['views/view', 'text!templates/post.hbs'], function(View, template) {
       PostView.__super__.constructor.apply(this, arguments);
     }
 
-    PostView.template = template;
+    PostView.prototype.template = template;
 
     PostView.prototype.tagName = 'li';
 

--- a/js/views/posts_view.js
+++ b/js/views/posts_view.js
@@ -12,7 +12,7 @@ define(['mediator', 'views/collection_view', 'views/post_view', 'text!templates/
       PostsView.__super__.constructor.apply(this, arguments);
     }
 
-    PostsView.template = template;
+    PostsView.prototype.template = template;
 
     PostsView.prototype.tagName = 'div';
 

--- a/js/views/sidebar_view.js
+++ b/js/views/sidebar_view.js
@@ -14,7 +14,7 @@ define(['mediator', 'views/view', 'text!templates/sidebar.hbs'], function(mediat
       SidebarView.__super__.constructor.apply(this, arguments);
     }
 
-    SidebarView.template = template;
+    SidebarView.prototype.template = template;
 
     SidebarView.prototype.id = 'sidebar';
 

--- a/js/views/view.js
+++ b/js/views/view.js
@@ -156,10 +156,10 @@ define(['lib/utils', 'lib/subscriber', 'lib/view_helper'], function(utils, Subsc
     View.prototype.render = function() {
       var html, template;
       if (this.disposed) return;
-      template = this.constructor.template;
+      template = this.template;
       if (typeof template === 'string') {
         template = Handlebars.compile(template);
-        this.constructor.template = template;
+        this.template = template;
       }
       if (typeof template === 'function') {
         html = template(this.getTemplateData());


### PR DESCRIPTION
`template` vars in views shouldn't be static for concistency with `model: model` in collections which aren't static too.
