### PR TITLE
Internal links

### DIFF
--- a/coffee/chaplin/views/application_view.coffee
+++ b/coffee/chaplin/views/application_view.coffee
@@ -130,7 +130,10 @@ define [
       # Pass to the router
       mediator.publish '!router:route', path, (routed) ->
         # Prevent default handling if the URL could be routed
-        event.preventDefault() if routed
+        if routed
+          event.preventDefault()
+        else
+          window.location.href = path
 
     # Not only A elements might act as internal links,
     # every element might have:


### PR DESCRIPTION
Un-routed internal links are not working for me in the development branch.  This fixed it for me but I'm unsure if it is truly the correct change.  

In theory, openInternalLink should be returning an Object, which openLink should then return, which should evaluate to true, allowing the browser to navigate to the href.  Not sure why this isn't the case in practice.
