### PR TITLE
Re-enable View#delegateEvents

### DIFF
--- a/coffee/chaplin/views/view.coffee
+++ b/coffee/chaplin/views/view.coffee
@@ -97,12 +97,6 @@ define [
     # User input event handling
     # -------------------------
 
-    # Make delegateEvents defunct, it is not used in our approach
-    # but is called by Backbone internally. Please use `delegate` and
-    # `undelegate` (see below) instead of the `events` hash.
-    delegateEvents: ->
-      # Noop
-
     # Event handling using event delegation
     # Register a handler for a specific event type
     # For the whole view:

--- a/js/chaplin/views/view.js
+++ b/js/chaplin/views/view.js
@@ -58,8 +58,6 @@ define(['jquery', 'underscore', 'backbone', 'chaplin/lib/utils', 'chaplin/lib/su
       if (autoRender) return this.render();
     };
 
-    View.prototype.delegateEvents = function() {};
-
     View.prototype.delegate = function(eventType, second, third) {
       var handler, selector;
       if (typeof eventType !== 'string') {


### PR DESCRIPTION
Re-enable Backbone’s delegateEvents so the events hash for registering DOM event handlers declaratively works again

Closes issue #42
