### PR TITLE
Cleanup the Facebook ServiceProvider

### DIFF
--- a/coffee/lib/services/service_provider.coffee
+++ b/coffee/lib/services/service_provider.coffee
@@ -66,9 +66,10 @@ define [
     # Callback for the login popup
     loginHandler: (loginContext, response) =>
 
+      eventPayload = {provider: this, loginContext}
       if response
         # Publish successful login
-        mediator.publish 'loginSuccessful', {provider: this, loginContext}
+        mediator.publish 'loginSuccessful', eventPayload
 
         # Publish the session
         mediator.publish 'serviceProviderSession',
@@ -78,7 +79,7 @@ define [
           # etc.
 
       else
-        mediator.publish 'loginFail', {provider: this, loginContext}
+        mediator.publish 'loginFail', eventPayload
 
     getLoginStatus: (callback = @loginStatusHandler, force = false) ->
       ServiceProviderLibrary.getLoginStatus callback, force

--- a/js/lib/services/service_provider.js
+++ b/js/lib/services/service_provider.js
@@ -56,9 +56,10 @@ define(['underscore', 'lib/utils', 'chaplin/lib/subscriber'], function(_, utils,
       # Callback for the login popup
       loginHandler: (loginContext, response) =>
   
+        eventPayload = {provider: this, loginContext}
         if response
           # Publish successful login
-          mediator.publish 'loginSuccessful', {provider: this, loginContext}
+          mediator.publish 'loginSuccessful', eventPayload
   
           # Publish the session
           mediator.publish 'serviceProviderSession',
@@ -68,7 +69,7 @@ define(['underscore', 'lib/utils', 'chaplin/lib/subscriber'], function(_, utils,
             # etc.
   
         else
-          mediator.publish 'loginFail', {provider: this, loginContext}
+          mediator.publish 'loginFail', eventPayload
   
       getLoginStatus: (callback = @loginStatusHandler, force = false) ->
         ServiceProviderLibrary.getLoginStatus callback, force


### PR DESCRIPTION
- Remove duplicate call of `getLoginStatus` after `loginAbort`
  (Btw, it’s an anti-pattern that a module listens to an event which is triggered by itself – I think I have to remove that from several modules, I did that already on moviepilot.com)
- Correctly pass the `loginContext` to `loginStatusAfterAbort`. This fixes an exception when aborting the login by closing the FB popup.
- Rename `facebook_commment` event to `facebook:comment` to be consistent with `facebook:like`. Probably this was just a typo.
- Remove `postToStream`, you should not do this, this is a legacy method. FB custom edges are the new thing.
- Delete `status` and `accessToken` properties on disposal.
- Optimize/reuse the event payload object
