### PR TITLE
Add options support to setCookie.

### DIFF
--- a/coffee/chaplin/lib/utils.coffee
+++ b/coffee/chaplin/lib/utils.coffee
@@ -85,12 +85,12 @@ define [
 
     # Get a cookie by its name
     getCookie: (key) ->
-      keyPosition = document.cookie.indexOf "#{key}="
-      return false if keyPosition is -1
-      start = keyPosition + key.length + 1
-      end = document.cookie.indexOf ';', start
-      end = document.cookie.length if end is -1
-      decodeURIComponent(document.cookie.substring(start, end))
+      pairs = document.cookie.split('; ')
+      for pair in pairs
+        val = pair.split('=')
+        if decodeURIComponent(val[0]) is key
+          return decodeURIComponent(val[1] or '')
+      null
 
     # Set a session cookie
 


### PR DESCRIPTION
I always forgot about the idea that if you're currently at `/path/0/1/2` and you do `document.cookie = 'a=b'`, the cookie will exist only in the path. New API option:

``` coffeescript
utils.setCookie 'access_token', @accessToken, path: '/'
```
