### PR TITLE
Topics/responsive clicks

### DIFF
--- a/coffee/chaplin/views/layout.coffee
+++ b/coffee/chaplin/views/layout.coffee
@@ -94,13 +94,13 @@ define [
     initLinkRouting: ->
       # Handle links
       $(document)
-        .on('click', '.go-to', @goToHandler)
-        .on('click', 'a', @openLink)
+        .on('touchstart mousedown', '.go-to', @goToHandler)
+        .on('touchstart mousedown', 'a', @openLink)
 
     stopLinkRouting: ->
       $(document)
-        .off('click', '.go-to', @goToHandler)
-        .off('click', 'a', @openLink)
+        .off('touchstart mousedown', '.go-to', @goToHandler)
+        .off('touchstart mousedown', 'a', @openLink)
 
     # Handle all clicks on A elements and try to route them internally
     openLink: (event) =>


### PR DESCRIPTION
Currently chaplin app listens for `click` on `a`. This will make it listen for `touchstart` & `mousedown` which is A LOT more responsive on mobile devices and slightly more responsive on PCs.
