### PR TITLE
Trigger 'dispose' on view disposal.

### DIFF
--- a/src/chaplin/views/view.coffee
+++ b/src/chaplin/views/view.coffee
@@ -347,6 +347,7 @@ define [
 
     dispose: ->
       return if @disposed
+      @trigger 'dispose'
 
       # Dispose subviews
       view.dispose() for view in @subviews


### PR DESCRIPTION
My use case:
- There is a post form (view), it's binded to a model.
- When it saves on the server, the view becomes useless.
- So I dispose it. In a parent view I listen for `dispose` event and create the same view (new & empty).
