### PR TITLE
Nested View Event Hashes

### DIFF
--- a/src/chaplin/views/view.coffee
+++ b/src/chaplin/views/view.coffee
@@ -173,7 +173,7 @@ define [
       if typeof parentEvents is 'function' then parentEvents = parentEvents()
       
       # Merge the parent events with the child events
-      events = _.extend {},parentEvents,childEvents
+      events = _.extend {}, parentEvents, childEvents
       
       super(events)
 


### PR DESCRIPTION
I've been toying with various ways to do nested view events today and thought this approach could be interesting.

It just checks to see if the parent has an events hash when it is constructed and merges them together if it does. 

I know we have View#delegate to handle this problem but I really wanted to find a way to use the declarative approach for events in parent and child views.

This is an idea I had but I thought I'd get some other opinions on it.
