### PR TITLE
logged-in & logged-out appear at same time

### DIFF
--- a/src/chaplin/views/layout.coffee
+++ b/src/chaplin/views/layout.coffee
@@ -93,7 +93,7 @@ define [
     # Logged-in / logged-out classes for the body element
     # ---------------------------------------------------
 
-    updateLoginClasses: (loggedIn) ->
+    updateLoginClasses: (loggedIn = no) ->
       $(document.body)
         .toggleClass('logged-out', not loggedIn)
         .toggleClass('logged-in', loggedIn)


### PR DESCRIPTION
When calling Layout#updateLoginClasses without arguments, the document body className will be 'logged-out logged-in', because jQuery only accept boolean as stateVal. 
