### PR TITLE
Fix CollectionView#insertView.

### DIFF
--- a/src/chaplin/views/collection_view.coffee
+++ b/src/chaplin/views/collection_view.coffee
@@ -319,7 +319,7 @@ define [
       $list = @$list
 
       # Get the children which originate from item views
-      children = $list.children @itemSelector
+      children = $list.children (@itemSelector or undefined)
       length = children.length
 
       if length is 0 or position is length


### PR DESCRIPTION
`$list.children null` gives empty list. `$list.children undefined` gives full list.

This fixes appending at right position.
