### PR TITLE
Bump version to 1.0.0-pre.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chaplin",
-  "version": "0.4.0-pre",
+  "version": "1.0.0-pre",
   "description": "An Application Architecture Using Backbone.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
[Semver](https://github.com/mojombo/semver/blob/master/semver.md) says:

> How do I know when to release 1.0.0?
> 
> If your software is being used in production, it should probably already be 1.0.0. If you have a stable API on which users have come to depend, you should be 1.0.0. If you're worrying a lot about backwards compatibility, you should probably already be 1.0.0.
- Chaplin is used in production.
- API is not that stable, but I propose to make it stable in upcoming release.
- 1.0.0 looks cooler
