### PR TITLE
Save current controller before calling it

### DIFF
--- a/src/chaplin/dispatcher.coffee
+++ b/src/chaplin/dispatcher.coffee
@@ -112,16 +112,16 @@ define [
       # Passing the params and the old controller name
       controller = new ControllerConstructor params, currentControllerName
 
-      # Call the specific controller action
-      # Passing the params and the old controller name
-      controller[action] params, currentControllerName
-
       # Save the new controller
       @previousControllerName = currentControllerName
       @currentControllerName = controllerName
       @currentController = controller
       @currentAction = action
       @currentParams = params
+
+      # Call the specific controller action
+      # Passing the params and the old controller name
+      controller[action] params, currentControllerName
 
       @adjustURL controller, params
 


### PR DESCRIPTION
I ran into this recently.

Let say I have a controller action like this

```
class Books extend ChaplinController

  show: ->
    unless loggedIn
      Backbone.history.navigate('/', true)
    else
      Do something
```

The Dispatcher will call show, it'll call Backbone.history.navigate, the new controller will be instantiated and the action called. [Dispatch]currentController will still be null, so the Books controller won't get disposed even though you navigated away from it.

Or maybe there's a better way to force the navigation that I'm just missing
