### PR TITLE
Don't use :input.

### DIFF
--- a/src/chaplin/views/view.coffee
+++ b/src/chaplin/views/view.coffee
@@ -220,7 +220,7 @@ define [
     pass: (attribute, selector) ->
       @modelBind "change:#{attribute}", (model, value) =>
         $el = @$(selector)
-        if $el.is(':input')
+        if $el.is('input, textarea, select, button')
           $el.val value
         else
           $el.text value


### PR DESCRIPTION
It's a proprietary jQuery selector and non-standard CSS3.

Also it doesn't work in Zepto.js.
