### PR TITLE
Fix URL matching with query params

### DIFF
--- a/src/chaplin/lib/route.coffee
+++ b/src/chaplin/lib/route.coffee
@@ -56,7 +56,7 @@ define [
       # Save parameter name
       @paramNames.push paramName
       # Replace with a character class
-      '([^\/]+)'
+      '([^\/\?]+)'
 
     # Test if the route matches to a path (called by Backbone.History#loadUrl)
     test: (path) ->

--- a/test/spec/router_spec.coffee
+++ b/test/spec/router_spec.coffee
@@ -89,6 +89,15 @@ define [
       expect(params.three).toBe 'ü~ö~ä'
       expect(params.four).toBe encodeURIComponent('éêè')
 
+    it 'should extract URL path params along with query params', ->
+      router.match 'params/:one/:two/:three', 'null#null'
+      router.route '/params/123-foo/456-bar/3-three?referrer=mdp'
+      expect(_.isObject params).toBe true
+      expect(params.one).toBe '123-foo'
+      expect(params.two).toBe '456-bar'
+      expect(params.three).toBe '3-three'
+      expect(params.referrer).toBe 'mdp'
+
     it 'should accept a regular expression as pattern', ->
       router.match /^(\w+)\/(\w+)\/(\w+)$/, 'null#null'
       router.route '/raw/regular/expression'


### PR DESCRIPTION
While UTF-8 now work just fine, the regex is sucking in query params as well. 

Small change required to fix it along with tests.
