### PR TITLE
Fix for utils.readonly making existing property undefined on Android 2.3.6

### DIFF
--- a/src/chaplin/lib/utils.coffee
+++ b/src/chaplin/lib/utils.coffee
@@ -32,6 +32,7 @@ define [
           configurable: false
         (obj, properties...) ->
           for prop in properties
+            readonlyDescriptor.value = obj[prop]
             Object.defineProperty obj, prop, readonlyDescriptor
           true
       else


### PR DESCRIPTION
Apparently `Object.defineProperty` overwrites existing property with default `undefined`.

Issue encountered in Android 2.3.6 browser:
Webapp dies when calling `mediator.unsubscribe` after it is made readonly, because `mediator.unsubscribe == undefined` at that point.
