### PR TITLE
Create separate dirs for builders. Add commit hash to filenames.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
-build/chaplin*
+build/amd
+build/commonjs
 test/js/*.js
 test/js/*/*.js
 test/js/*/*/*.js


### PR DESCRIPTION
If chaplin's version in `package.json` is `1.0.0-pre` (etc), it will create file `#{loader}/chaplin-1.0.0-pre-#{commit_hash}` where loader is `amd` or `commonjs` and `commit_hash` is first 7 letters of last git commit.

If version is `1.0.0` (etc), it will create file `#{loader}/chaplin-1.0.0`.
