### PR TITLE
Topics/fix path detection

### DIFF
--- a/src/chaplin/dispatcher.coffee
+++ b/src/chaplin/dispatcher.coffee
@@ -141,7 +141,7 @@ define [
 
     # Change the URL to the new controller using the router
     adjustURL: (controller, params) ->
-      if params.path || params.path is ''
+      if params.path or params.path is ''
         # Just use the matched path
         url = params.path
 


### PR DESCRIPTION
The following route definition:

`match '', 'controller#action'`

Will crash if you don't define `historyURL` in the controller. Thought the empty path is a valid path.

I added a check for the empty string.
