### PR TITLE
Add routing support for controllers in subfolders.

### DIFF
--- a/src/chaplin/dispatcher.coffee
+++ b/src/chaplin/dispatcher.coffee
@@ -91,8 +91,11 @@ define [
     # The default implementation uses require() from a AMD module loader
     # like RequireJS to fetch the constructor.
     loadController: (controllerName, handler) ->
+      # Look for the controller in the module path specified by :: (ex. modules/mymodule::helloWorld#show)
+      [controllerRedirectionPath, controllerName] = controllerName.split('::') if controllerName.indexOf('::') isnt -1
       controllerFileName = utils.underscorize(controllerName) + @settings.controllerSuffix
-      path = @settings.controllerPath + controllerFileName
+      path = if controllerRedirectionPath? then controllerRedirectionPath + '/' else '' # Prefix module path
+      path += @settings.controllerPath + controllerFileName
       if define?.amd
         require [path], handler
       else

--- a/test/spec/dispatcher_spec.coffee
+++ b/test/spec/dispatcher_spec.coffee
@@ -18,6 +18,7 @@ define [
 
     route1 = controller: 'test1', action: 'show'
     route2 = controller: 'test2', action: 'show'
+    route3 = controller: 'modules/mymodule::test3', action: 'show'
 
     redirectToURLRoute = controller: 'test1', action: 'redirectToURL'
     redirectToControllerRoute = controller: 'test1', action: 'redirectToController'
@@ -69,9 +70,27 @@ define [
         #console.debug 'Test2Controller#dispose'
         super
 
+    class Test3Controller extends Controller
+
+      historyURL: (params) ->
+        #console.debug 'Test1Controller#historyURL'
+        'test3/' + (params.id or '')
+
+      initialize: (params, oldControllerName) ->
+        #console.debug 'Test3Controller#initialize', params, oldControllerName
+        super
+
+      show: (params, oldControllerName) ->
+        #console.debug 'Test3Controller#show', params, oldControllerName
+
+      dispose: (params, newControllerName) ->
+        #console.debug 'Test3Controller#dispose'
+        super
+
     # Define a test controller AMD modules
     define 'controllers/test1_controller', -> Test1Controller
     define 'controllers/test2_controller', -> Test2Controller
+    define 'modules/mymodule/controllers/test3_controller', -> Test3Controller
 
     beforeEach refreshParams
 
@@ -262,6 +281,18 @@ define [
       expect(startupController.callCount).toBe 1
 
       mediator.unsubscribe 'startupController', startupController
+
+    it 'should be able to look in module subdirs for module controllers', ->
+      proto = Test3Controller.prototype
+      historyURL = spyOn(proto, 'historyURL').andCallThrough()
+      initialize = spyOn(proto, 'initialize').andCallThrough()
+      action     = spyOn(proto, 'show').andCallThrough()
+
+      mediator.publish 'matchRoute', route3, params
+
+      expect(initialize).toHaveBeenCalledWith params, 'test2'
+      expect(action).toHaveBeenCalledWith params, 'test2'
+      expect(historyURL).toHaveBeenCalledWith params
 
     it 'should dispose itself correctly', ->
       expect(typeof dispatcher.dispose).toBe 'function'


### PR DESCRIPTION
Modified the dispatcher to be able to look for controllers in subfolders by prefixing targets with double colons.

This way you will be able to have a folder structure like this:

collections
controllers
lib
models
modules
|--- mymodule
|---|--- collections
|---|--- controllers
|---|----|--- my_controller.coffee
|---|--- models

and so forth. To route to your module controllers just prefix your targets with "modulepath::" ex. modules/mymodule::my#action. Test included!

This allows for reusable selfcontained modules that you can reuse in other projects. I hope it will be useful to someone.
