### PR TITLE
Adds Delayer mixin and integrates into View.

### DIFF
--- a/src/chaplin/lib/delayer.coffee
+++ b/src/chaplin/lib/delayer.coffee
@@ -1,0 +1,50 @@
+define () ->
+  'use strict'
+
+  # Add functionality to set unique, named timeouts and intervals
+  # so they can be cleared afterwards when disposing the object.
+  #
+  # Mixin this object to add the delayer capability to any object:
+  # _(object).extend Delayer
+  # Or to a prototype of a class:
+  # _(@prototype).extend Delayer
+  #
+
+  Delayer =
+
+    setTimeout: (name, time, handler) ->
+      @clearTimeout(name)
+      @timeouts = @timeouts || {}
+      @timeouts[name] = setTimeout handler, time
+
+    clearTimeout: (name) ->
+      @timeouts = @timeouts || {}
+      clearTimeout @timeouts[name] if @timeouts[name]
+
+    clearAllTimeouts: ->
+      @timeouts = @timeouts || {}
+      _(@timeouts).chain().keys().each (name) =>
+        @clearTimeout name
+
+    setInterval: (name, time, handler) ->
+      @clearInterval(name)
+      @intervals = @intervals || {}
+      @intervals[name] = setInterval handler, time
+
+    clearInterval: (name) ->
+      @intervals = @intervals || {}
+      clearInterval(@intervals[name]) if @intervals[name]
+
+    clearAllIntervals: ->
+      @intervals = @intervals || {}
+      _(@intervals).chain().keys().each (name) =>
+        @clearInterval name
+
+    clearDelayed: ->
+      @clearAllTimeouts()
+      @clearAllIntervals()
+
+  # You’re frozen when your heart’s not open
+  Object.freeze? Delayer
+
+  Delayer

--- a/src/chaplin/views/view.coffee
+++ b/src/chaplin/views/view.coffee
@@ -4,14 +4,18 @@ define [
   'backbone',
   'chaplin/lib/utils',
   'chaplin/lib/subscriber',
+  'chaplin/lib/delayer',
   'chaplin/models/model'
-], ($, _, Backbone, utils, Subscriber, Model) ->
+], ($, _, Backbone, utils, Subscriber, Delayer, Model) ->
   'use strict'
 
   class View extends Backbone.View
 
     # Mixin a Subscriber
     _(@prototype).extend Subscriber
+
+    # Mixin a Delayer
+    _(@prototype).extend Delayer
 
     # Automatic rendering
     # -------------------
@@ -369,6 +373,9 @@ define [
 
       # Unbind handlers of global events
       @unsubscribeAllEvents()
+
+      # Clear all intervals and timeouts.
+      @clearDelayed()
 
       # Unbind all model handlers
       @modelUnbindAll()


### PR DESCRIPTION
Note: My CoffeeScript is rusty and this would need tests, so work is needed.

In our (plain js) chaplin app we use a number of timeouts and intervals for UI interaction.  These are primarily created and managed in views.  We're using a plain js version of this mixin to register all the timeouts and intervals so they can be cleared up when the view is disposed.

If you guys think this is a useful core feature then we can clean this up and add tests.
