### PR TITLE
Features/collection view filter callbacks

### DIFF
--- a/src/chaplin/views/collection_view.coffee
+++ b/src/chaplin/views/collection_view.coffee
@@ -214,14 +214,13 @@ defined (or the getView() must be overridden)'
       # Save the new filterer function
       @filterer = filterer
 
-      # default callback hides the model if included
-      # and calls @updateVisibleItems
-      callback ?= (view, model, included) =>
+      # Default callback (hides excluded items)
+      callback ?= (view, included) =>
         display = if included then '' else 'none'
         view.$el.stop(true, true).css('display', display)
         # Update visibleItems list, but do not trigger
         # a `visibilityChange` event immediately
-        @updateVisibleItems model, included, false
+        @updateVisibleItems view.model, included, false
 
       # Show/hide existing views
       unless _(@viewsByCid).isEmpty()
@@ -240,8 +239,8 @@ defined (or the getView() must be overridden)'
             throw new Error 'CollectionView#filter: ' +
               "no view found for #{item.cid}"
 
-          # run the callback on the view
-          callback view, item, included
+          # Apply callback
+          callback view, included
 
       # Trigger a combined `visibilityChange` event
       @trigger 'visibilityChange', @visibleItems

--- a/test/spec/collection_view_spec.coffee
+++ b/test/spec/collection_view_spec.coffee
@@ -273,7 +273,7 @@ define [
       addThree()
       filterer = (model, position) ->
         model.get('title') is 'new'
-      callback = (view, model, included) ->
+      callback = (view, included) ->
         view.$el.css('background-color', 'rgb(255, 0, 0)') if included
       collectionView.filter filterer, callback
 


### PR DESCRIPTION
I ran into this while trying to filter a list whose items were css `display: inline-block` instead of `display: block`, and I realized not all of the list filtering was going to be to hide or unhide items. An optional callback seemed like the right solution (h/t Rendez)
