### PR TITLE
Node path to coffeescript incorrect.

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ There’s a Ruby build script in `build/build.rb` which compiles the CoffeeScrip
 Also, you need to install the Node packages for CoffeeScript and UglifierJS globally:
 
 ```
-sudo npm install -g coffee 
+sudo npm install -g coffee-script
 sudo npm install -g uglify-js
 ```
 


### PR DESCRIPTION
Quick correction for the node path to coffeescript. The following returns an error:

```
10:42 ~/elc/chaplin (master)$ sudo npm install -g coffee

npm http GET https://registry.npmjs.org/coffee
npm http 404 https://registry.npmjs.org/coffee
npm ERR! 404 'coffee' is not in the npm registry.
npm ERR! 404 You should bug the author to publish it
npm ERR! 404 
npm ERR! 404 Note that you can also install from a
npm ERR! 404 tarball, folder, or http url, or git url.

npm ERR! System Darwin 11.4.0
npm ERR! command "node" "/usr/local/bin/npm" "install" "-g" "coffee"
npm ERR! cwd /Users/ktmiller/elc/chaplin
npm ERR! node -v v0.8.4
npm ERR! npm -v 1.1.45
npm ERR! code E404
npm ERR! 
npm ERR! Additional logging details can be found in:
npm ERR!     /Users/ktmiller/elc/chaplin/npm-debug.log
npm ERR! not ok code 0
```
