### PR TITLE
Fix renderAllItems() for existing CollectionViews

### DIFF
--- a/src/chaplin/views/collection_view.coffee
+++ b/src/chaplin/views/collection_view.coffee
@@ -346,10 +346,10 @@ defined (or the getView() must be overridden)'
         # Insert at the right position
         if position is 0
           $next = children.eq position
-          $next.before viewEl
+          $next.before viewEl unless $next[0] is viewEl
         else
           $previous = children.eq position - 1
-          $previous.after viewEl
+          $previous.after viewEl unless $previous[0] is viewEl
 
       # Tell the view that it was added to the DOM
       view.trigger 'addedToDOM'


### PR DESCRIPTION
An existing element cannot be moved using itself
as the DOM reference point when calling $.before
or $.after. Doing so will simply delete the node.
Fixed the method insertView in renderAllItems to
account for this.
