### PR TITLE
Subviews are not shown when bound to container that is created only after parent view is rendered

### DIFF
--- a/src/chaplin/views/view.coffee
+++ b/src/chaplin/views/view.coffee
@@ -351,6 +351,10 @@ define [
     afterRender: ->
       # Automatically append to DOM if the container element is set
       if @container
+        # Container element may not exist yet at the time render function was called, 
+        # so try once more to get it
+        unless @container.length
+          @container = $(@container.selector)
         # Append the view to the DOM
         $(@container)[@containerMethod] @el
         # Trigger an event


### PR DESCRIPTION
Encountered this problem when used subview function.

Here is my code:

``` javascript
var DashboardController = Controller.extend({
    ........
    main: function(params) {
        var buttons = new ButtonCollection([new Button({text: "AAA", href: '/'})]);
        this.view = new DashboardView();
        this.view.subview('buttons', new ButtonCollectionView({collection: buttons}));
    },
});

var DashboardView = View.extend({
    template: template,
    container: $('#main'),
    autoRender: true,
    tagName: "section",
    className: "apps-container"
});

var ButtonCollectionView = CollectionView.extend({
    itemView: ButtonView,
    container: $('.apps-container')
});
```

Button, ButtonView and ButtonCollection are of Model, View and Collection types respectively.

"section.apps-container" container is created after DashboardView is rendered.
ButtonCollectionView is bound to this container. 

When I debugged such call in my controller:

``` javascript
this.view.subview('buttons', new ButtonCollectionView({collection: buttons}));
```

it turned out that in View.afterRender method for my CollectionView "container" variable is empty array, though "section.apps-container" already exists in DOM. So subview was not added to DOM.

While with such call:

``` javascript
this.view.subview('buttons', new ButtonCollectionView({collection: buttons, container: $(".apps-container")}));
```

Everything worked OK.

So I propose to do one more check for container in View.afterRender method:

``` javascript
View.prototype.afterRender = function() {
    if (this.container) {
        if (!this.container.length) {
            this.container = $(this.container.selector);
        }
        $(this.container)[this.containerMethod](this.el);
        return this.trigger('addedToDOM');
    }
};
```
