### PR TITLE
Check instanceof Backbone.Model instead of Chaplin.Model in serializeAtt...

### DIFF
--- a/src/chaplin/models/model.coffee
+++ b/src/chaplin/models/model.coffee
@@ -39,7 +39,7 @@ define [
         modelStack.push model
       # Map model/collection to their attributes
       for key, value of attributes
-        if value instanceof Model
+        if value instanceof Backbone.Model
           # Don’t change the original attribute, create a property
           # on the delegator which shadows the original attribute
           delegator ?= utils.beget attributes


### PR DESCRIPTION
...ributes function

Hi, was there a particular reason to check there for Chaplin.Model instead of Backbone.Model?

Using Backbone.Model there will allow easier mixin of Chaplin.Model with other classes inherited from Backbone.Model.

For example, in my case:

Backbone.Model -> Backbone.RelationalModel (https://github.com/PaulUithol/Backbone-relational)
Backbone.Model -> Chaplin.Model

If I want to have Chaplin.RelationalModel, then I do it in following way:

``` javascript
var RelationalModel = Backbone.RelationalModel.extend();

_.extend(RelationalModel.prototype, utils.getObjectWithOwnProperties(Chaplin.Model.prototype));

return RelationalModel;
```

where

``` javascript
getObjectWithOwnProperties: function(obj) {
    var props = {};

    for (var prop in obj){
        if (obj.hasOwnProperty(prop)) {
            props[prop] = obj[prop];
        }
    }

    return props;
}
```

So my RelationalModel will be of type Backbone.Model, but not of type Chaplin.Model, and serialization will work incorrectly.
The proposed change fixes this situation.
