### PR TITLE
Enable multiple requirejs contexts

### DIFF
--- a/src/chaplin/dispatcher.coffee
+++ b/src/chaplin/dispatcher.coffee
@@ -1,10 +1,11 @@
 define [
+  'require'
   'underscore'
   'backbone'
   'chaplin/mediator'
   'chaplin/lib/utils'
   'chaplin/lib/subscriber'
-], (_, Backbone, mediator, utils, Subscriber) ->
+], (require, _, Backbone, mediator, utils, Subscriber) ->
   'use strict'
 
   class Dispatcher


### PR DESCRIPTION
Adding require as dependency for Dispatcher allows Dispatcher to use the correct "require" instance in  multiple-context environments.

Example: When using Aloha editor in a Chaplin app, Aloha is being
loaded in a different requirejs context. Chaplin thus uses require with
a wrong baseUrl setting and cannot find controllers.

Adding require as dependency for Dispatcher fixes that.
