### PR TITLE
Integrate Delayer as an optional module

### DIFF
--- a/src/chaplin/lib/delayer.coffee
+++ b/src/chaplin/lib/delayer.coffee
@@ -1,48 +1,75 @@
-define () ->
+define ->
   'use strict'
 
+  # Delayer
+  # -------
+  #
   # Add functionality to set unique, named timeouts and intervals
   # so they can be cleared afterwards when disposing the object.
+  # This is especially useful in your custom View class which inherits
+  # from the standard Chaplin.View.
   #
   # Mixin this object to add the delayer capability to any object:
   # _(object).extend Delayer
+  #
   # Or to a prototype of a class:
   # _(@prototype).extend Delayer
   #
+  # In the dispose method, call `clearDelayed` to remove all pending
+  # timeouts and running intervals:
+  #
+  # dispose: ->
+  #   return if @disposed
+  #   @clearDelayed()
+  #   super
 
   Delayer =
 
     setTimeout: (name, time, handler) ->
-      @clearTimeout(name)
-      @timeouts = @timeouts || {}
-      @timeouts[name] = setTimeout handler, time
+      @timeouts ?= {}
+      @clearTimeout name
+      wrappedHandler = =>
+        delete @timeouts[name]
+        handler()
+      handle = setTimeout wrappedHandler, time
+      @timeouts[name] = handle
+      handle
 
     clearTimeout: (name) ->
-      @timeouts = @timeouts || {}
-      clearTimeout @timeouts[name] if @timeouts[name]
+      return unless @timeouts and @timeouts[name]?
+      clearTimeout @timeouts[name]
+      delete @timeouts[name]
+      return
 
     clearAllTimeouts: ->
-      @timeouts = @timeouts || {}
-      _(@timeouts).chain().keys().each (name) =>
+      return unless @timeouts
+      for name, handle of @timeouts
         @clearTimeout name
+      return
 
     setInterval: (name, time, handler) ->
-      @clearInterval(name)
-      @intervals = @intervals || {}
-      @intervals[name] = setInterval handler, time
+      @clearInterval name
+      @intervals ?= {}
+      handle = setInterval handler, time
+      @intervals[name] = handle
+      handle
 
     clearInterval: (name) ->
-      @intervals = @intervals || {}
-      clearInterval(@intervals[name]) if @intervals[name]
+      return unless @intervals and @intervals[name]
+      clearInterval @intervals[name]
+      delete @intervals[name]
+      return
 
     clearAllIntervals: ->
-      @intervals = @intervals || {}
-      _(@intervals).chain().keys().each (name) =>
+      return unless @intervals
+      for name, handle of @intervals
         @clearInterval name
+      return
 
     clearDelayed: ->
       @clearAllTimeouts()
       @clearAllIntervals()
+      return
 
   # You’re frozen when your heart’s not open
   Object.freeze? Delayer

--- a/src/chaplin/views/view.coffee
+++ b/src/chaplin/views/view.coffee
@@ -4,18 +4,14 @@ define [
   'backbone',
   'chaplin/lib/utils',
   'chaplin/lib/subscriber',
-  'chaplin/lib/delayer',
   'chaplin/models/model'
-], ($, _, Backbone, utils, Subscriber, Delayer, Model) ->
+], ($, _, Backbone, utils, Subscriber, Model) ->
   'use strict'
 
   class View extends Backbone.View
 
     # Mixin a Subscriber
     _(@prototype).extend Subscriber
-
-    # Mixin a Delayer
-    _(@prototype).extend Delayer
 
     # Automatic rendering
     # -------------------
@@ -373,9 +369,6 @@ define [
 
       # Unbind handlers of global events
       @unsubscribeAllEvents()
-
-      # Clear all intervals and timeouts.
-      @clearDelayed()
 
       # Unbind all model handlers
       @modelUnbindAll()

--- a/test/README
+++ b/test/README
@@ -7,3 +7,6 @@ coffee --bare --output test/js/ test/spec/
 This compiles both to the directory test/js/.
 
 Now open test/index.html in a browser to run the tests.
+
+For test-driven development, start both commands with the --watch option
+so the code is compiled whenever the library or the test code changes.

--- a/test/index.html
+++ b/test/index.html
@@ -46,7 +46,8 @@
           'model',
           'collection',
           'controller',
-          'view'
+          'view',
+          'delayer'
         ];
         var loaded = [];
         for (var i = 0, l = specs.length; i < l; i++) {

--- a/test/spec/delayer_spec.coffee
+++ b/test/spec/delayer_spec.coffee
@@ -1,0 +1,125 @@
+define [
+  'underscore'
+  'chaplin/lib/delayer'
+], (_, Delayer) ->
+  'use strict'
+
+  describe 'Delayer', ->
+    #console.debug 'Delayer spec'
+
+    # Set up an object which mixes in Delayer
+    delayer = {}
+    _(delayer).extend Delayer
+
+    it 'should be a simple object', ->
+      expect(Delayer).to.be.an 'object'
+
+    it 'should allow to set a timeout ', (done) ->
+      expect(delayer.setTimeout).to.be.a 'function'
+      handle = delayer.setTimeout 'foo', 1, ->
+        done()
+      expect(handle).to.be.a 'number'
+
+    it 'should create a timeout handle store', (done) ->
+      expect(delayer.timeouts).to.be.an 'object'
+      delayer.setTimeout 'foo', 1, ->
+        done()
+      expect(delayer.timeouts.foo).to.be.a 'number'
+
+    it 'should set multiple timeouts with different name', (done) ->
+      spy1 = sinon.spy()
+      spy2 = sinon.spy()
+      delayer.setTimeout 'foo', 1, spy1
+      delayer.setTimeout 'bar', 1, spy2
+      setTimeout ->
+        expect(spy1).was.called()
+        expect(spy2).was.called()
+        done()
+      , 1
+
+    it 'should not set a timeout twice', (done) ->
+      spy1 = sinon.spy()
+      spy2 = sinon.spy()
+      delayer.setTimeout 'foo', 1, spy1
+      delayer.setTimeout 'foo', 1, spy2
+      setTimeout ->
+        expect(spy1).was.notCalled()
+        expect(spy2).was.called()
+        done()
+      , 1
+
+    it 'should remove called timeouts', ->
+      expect(delayer.timeouts.foo).to.equal undefined
+
+    it 'should allow to clear a timeout', (done) ->
+      spy = sinon.spy()
+      delayer.setTimeout 'foo', 1, spy
+      expect(delayer.clearTimeout).to.be.a 'function'
+      delayer.clearTimeout 'foo'
+      setTimeout (->
+        expect(spy).was.notCalled()
+        done()
+      ), 1
+
+    it 'should clear all timeouts', (done) ->
+      spy1 = sinon.spy()
+      spy2 = sinon.spy()
+      delayer.setTimeout 'foo', 1, spy1
+      delayer.setTimeout 'bar', 1, spy2
+      expect(delayer.clearAllTimeouts).to.be.a 'function'
+      delayer.clearAllTimeouts()
+      setTimeout ->
+        expect(spy1).was.notCalled()
+        expect(spy2).was.notCalled()
+        done()
+      , 1
+
+    it 'should allow to set and get an interval', ->
+      spy = sinon.spy()
+      setIntervalStub = sinon.stub(window, 'setInterval').callsArg(0).returns(12345)
+      expect(delayer.setInterval).to.be.a 'function'
+      handle = delayer.setInterval 'foo', 50, spy
+      expect(handle).to.equal 12345
+      expect(setIntervalStub).was.called()
+      expect(spy).was.called()
+      setIntervalStub.restore()
+
+    it 'should create a interval handle store', ->
+      setIntervalStub = sinon.stub(window, 'setInterval').returns(12345)
+      expect(delayer.intervals).to.be.an 'object'
+      delayer.setInterval 'foo', 1, ->
+      expect(delayer.intervals.foo).to.equal 12345
+      setIntervalStub.restore()
+
+    it 'should allow to clear an interval', ->
+      spy = sinon.spy()
+      clearIntervalStub = sinon.stub window, 'clearInterval'
+      handle = delayer.setInterval 'foo', 1, spy
+      expect(delayer.clearInterval).to.be.a 'function'
+      delayer.clearInterval 'foo'
+      expect(clearIntervalStub).was.calledWith handle
+      clearIntervalStub.restore()
+
+    it 'should clear all timeouts', ->
+      i = 0
+      setIntervalStub   = sinon.stub window, 'setInterval', -> ++i
+      clearIntervalStub = sinon.stub window, 'clearInterval'
+      handle1 = delayer.setInterval 'foo', 1, ->
+      handle2 = delayer.setInterval 'bar', 1, ->
+      expect(delayer.clearAllIntervals).to.be.a 'function'
+      delayer.clearAllIntervals()
+      expect(clearIntervalStub.callCount).to.equal 2
+      expect(clearIntervalStub.getCall(0).args[0]).to.equal handle1
+      expect(clearIntervalStub.getCall(1).args[0]).to.equal handle2
+      setIntervalStub.restore()
+      clearIntervalStub.restore()
+
+    it 'should clear all timeouts and intervals', ->
+      stub1 = sinon.stub delayer, 'clearAllTimeouts'
+      stub2 = sinon.stub delayer, 'clearAllIntervals'
+      expect(delayer.clearDelayed).to.be.a 'function'
+      delayer.clearDelayed()
+      expect(stub1).was.called()
+      expect(stub2).was.called()
+      stub1.restore()
+      stub2.restore()


### PR DESCRIPTION
Add @cpsubrian’s Delayer as an optional module, together with unit tests (see #158).

I used stubs only for the interval tests, we could also use them for the timeout stuff, but calling setTimeout is easier to test, so I just used the `done()` feature of Mocha.
