### PR TITLE
avoid null error on dispose when view has no subviews

### DIFF
--- a/src/chaplin/views/view.coffee
+++ b/src/chaplin/views/view.coffee
@@ -365,7 +365,7 @@ define [
       return if @disposed
 
       # Dispose subviews
-      subview.dispose() for subview in @subviews
+      subview.dispose() for subview in @subviews if @subviews?
 
       # Unbind handlers of global events
       @unsubscribeAllEvents()


### PR DESCRIPTION
I'm getting a bug when I try to dispose of a view without any subviews. 

```
_ref = this.subviews
for (_i = 0, _len = _ref.length; _i < _len; _i++) {
   ...
}
```

This is a standard coffeescript `for subview in @subviews` loop, but it fails when @subviews is undefined
