### PR TITLE
Added `.editorconfig` file; declare global use of style.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,7 +1,9 @@
 root = true
 
 [*]
-end_of_line = lf
-insert_final_newline = true
-indent_style = space
-indent_size = 2
+charset                  = utf-8
+end_of_line              = lf
+indent_style             = space
+indent_size              = 2
+trim_trailing_whitespace = true
+insert_final_newline     = true


### PR DESCRIPTION
See http://editorconfig.org/

Nice way of declaring indent style that is detected by most editors. Normally I use 4-space indent but when I'm in chaplin this file allows my editor (Sublime) to auto adjust to 2-space indent.
