### PR TITLE
Option to apply RegExp from constraints to match named params.

### DIFF
--- a/src/chaplin/lib/route.coffee
+++ b/src/chaplin/lib/route.coffee
@@ -60,6 +60,12 @@ define [
       @paramNames.push paramName
       # Replace with a character class
       if match.charAt(0) is ':'
+        # Must have constraints and be allowed to apply them as RegExp
+        constraints = @options.applyConstraints and @options.constraints
+        # Apply the param name as it matches a named constraint
+        if constraints
+          # Regexp for constrained :foo
+          return constraints[paramName].source
         # Regexp for :foo
         '([^\/\?]+)'
       else

--- a/src/chaplin/lib/router.coffee
+++ b/src/chaplin/lib/router.coffee
@@ -22,6 +22,7 @@ define [
     constructor: (@options = {}) ->
       _(@options).defaults
         pushState: true
+        applyConstraints: false
 
       @subscribeEvent '!router:route', @routeHandler
       @subscribeEvent '!router:changeURL', @changeURLHandler
@@ -45,7 +46,7 @@ define [
     # Directly create a route on the Backbone.History instance
     match: (pattern, target, options = {}) =>
       # Create the route
-      route = new Route pattern, target, options
+      route = new Route pattern, target, _(applyConstraints: @options.applyConstraints).extend(options)
       # Register the route at the Backbone.History instance.
       # Don’t use Backbone.history.route here because it calls
       # handlers.unshift, inserting the handler at the top of the list.

--- a/test/spec/router_spec.coffee
+++ b/test/spec/router_spec.coffee
@@ -195,7 +195,23 @@ define [
       expect(spy).was.called()
 
       mediator.unsubscribe 'matchRoute', spy
+    
+    it 'should use constraints to extract named parameters', ->
+      router.options.applyConstraints = true
+      router.match 'constraints/:id', 'null#null',
+        constraints:
+          id: /(\d+)/
 
+      router.route '/constraints/123'
+      expect(params.id).to.be '123'
+      
+      router.match 'constraints/:id', 'null#null',
+        constraints:
+          id: /([\d]+)[\w\-$]*/
+
+      router.route '/constraints/123-foo'
+      expect(params.id).to.be '123'
+    
     it 'should pass fixed parameters', ->
       router.match 'fixed-params/:id', 'null#null',
         params:


### PR DESCRIPTION
I came up with this while integrating routes at moviepilot.com. For us, as well as a great other number of sites, the use of pretty URLs is extensive. Therefore, extracting the numeric ID from a URL can be done in a controller action, but it should be a feature of the Router/Route to be able to extract it given a RegExp, after matching with the path.

For this I've taken a simple, non-breaking approach where Router may be passed an option `applyConstraints` which gets delegated to every new `Route` instance it creates, to allow the use of defined `constraints` for matching named params, e.g.:

``` coffee
router.match 'constraints/:id', 'null#null',
  constraints:
    id: /([\d]+)[\w\-$]*/

router.route '/constraints/123-foo'
```

The containing params object shall expose `id` with value of `123`, while we're still be able to use the constraint as usual.
