### PR TITLE
Bug Fix: Stop @dispose from faiing when @subviews are not used on a view

### DIFF
--- a/src/chaplin/views/view.coffee
+++ b/src/chaplin/views/view.coffee
@@ -373,7 +373,8 @@ define [
       return if @disposed
 
       # Dispose subviews
-      subview.dispose() for subview in @subviews
+      if @subviews
+        subview.dispose() for subview in @subviews
 
       # Unbind handlers of global events
       @unsubscribeAllEvents()


### PR DESCRIPTION
I was having trouble using @dispose on a view - it kept erroring out on @dispose when @dispose would want to clean up any sub views. I just simply asked it to check if @subviews is there.
