### PR TITLE
Option names array in match route definitions

### DIFF
--- a/src/chaplin/lib/route.coffee
+++ b/src/chaplin/lib/route.coffee
@@ -39,6 +39,7 @@ define [
     createRegExp: ->
       if _.isRegExp(@pattern)
         @regExp = @pattern
+        @paramNames = @options.names if _.isArray @options.names
         return
 
       pattern = @pattern

--- a/test/spec/router_spec.coffee
+++ b/test/spec/router_spec.coffee
@@ -151,6 +151,14 @@ define [
       expect(params.one).to.be '123-foo'
       expect(params.p_two_123).to.be '456-bar'
 
+    it 'should name parameters of a regular expression with `names` option array', ->
+      router.match /^params\/(\d+)\/(\w+)$/, 'null#null',
+        names: ['one', 'two']
+      router.route '/params/123/foo'
+      expect(params).to.be.an 'object'
+      expect(params.one).to.be '123'
+      expect(params.two).to.be 'foo'
+
     it 'should extract non-ascii named parameters', ->
       router.match 'params/:one/:two/:three/:four', 'null#null'
       router.route "/params/o_O/*.*/ü~ö~ä/#{encodeURIComponent('éêè')}"


### PR DESCRIPTION
``` coffee
router.match /products\/(\d+)[\w\-$]*/, 'null#null',
  names: ['id']

router.route '/products/123-foo'
# delivers 'params.id=123' for the matching route
```
