### PR TITLE
View docs updates

### DIFF
--- a/docs/chaplin.application.md
+++ b/docs/chaplin.application.md
@@ -10,14 +10,14 @@ The `Chaplin.Application` is a bootstrapper which provides methods to start othe
 <a name="initDispatcher"></a>
 
 ### initDispatcher( [options={}] )
-Initialize `Chaplin.Dispatcher`. Look at `Chaplin.Dispatcher` [documentation](/docs/dispatcher.html) for more details about the options.
+Initialize `Chaplin.Dispatcher`. Look at `Chaplin.Dispatcher` [documentation](./chaplin.dispatcher.md) for more details about the options.
 
 * **options**: the option for the Dispatcher
 
 <a name="initLayout"></a>
 
 ### initLayout( [options={}] )
-Initialize `Chaplin.Layout`. [Chaplin.Layout documentation](/docs/layout.html)
+Initialize `Chaplin.Layout`. [Chaplin.Layout documentation](./chaplin.layout.md)
 
 * **options**: none for now.
 
@@ -25,7 +25,7 @@ Initialize `Chaplin.Layout`. [Chaplin.Layout documentation](/docs/layout.html)
 <a name="initRouter"></a>
 
 ### initRouter( routes, [options={}] )
-Initialize `Chaplin.Router`. [Chaplin.Router documentation](/docs/router.html)
+Initialize `Chaplin.Router`. [Chaplin.Router documentation](./chaplin.router.md)
 
 * **routes**: the routes defined in the routes file
 * **options**: none
@@ -69,7 +69,7 @@ define [
     initialize: ->
       # ...
 
-      @layout = new Layout {@title} # option 1: instanciate directly the Layout
+      @layout = new Layout {@title} # option 1:  directly instantiate the Layout
       # OR
       @initLayout()                 # option 2: we still call initLayout...
 

--- a/docs/chaplin.collection_view.md
+++ b/docs/chaplin.collection_view.md
@@ -2,18 +2,200 @@
 
 The `CollectionView` is responsible for displaying collections. For every item in a collection, it instantiates a given item view and inserts it into the DOM. It reacts to collection change events (`add`, `remove` and `reset`) and provides basic filtering, caching of views, fallback content and loading indicators.
 
+## Properties of `Chaplin.CollectionView`
+
+<a id="itemView"></a>
+### itemView
+* **a View that extends from Chaplin.View (default null)**
+
+  Your item View class, which will represent the individual items
+  in the collection
+
+<a id="autoRender"></a>
+### autoRender
+* **boolean (default true)**
+
+  Render the view automatically on instantiation. This overrides
+  Chaplin.View's default of false. Your inheriting classes (and
+  instatiated objects via the options hash) can set their own value.
+
+<a id="renderItems"></a>
+###  RenderItems
+* **boolean (default true)**
+
+  Should the view automatically render all items on instantiation?
+
+  Can be passed during instantiation via the options hash.
+
+<a id="animationDuration"></a>
+### animationDuration
+* **int, duration in ms (default 500)**
+
+  When new items are added, their views are faded in over a period of
+  `animationDuration` milliseconds. Set to 0 to disable fade in.
+
+<a id="useCssAnimation"></a>
+### useCssAnimation
+* **boolean (default false)**
+
+  By default, fading in is done by javascript function which can be
+  slow on mobile devices. CSS animations are faster,
+  but require user’s manual definitions.
+
+  CSS classes used are: **animated-item-view**, **animated-item-view-end**.
+
+<a id="methods-overview"></a>
 ## Methods of `Chaplin.CollectionView`
+  Most of CollectionView's methods should not need to be called
+  externally. Modifying the underlying collection will automatically
+  update the items on screen (for instance, fetching more models
+  from the server), as the view listens for `add`, `remove`, and
+  `reset` events by default.
 
-### method1(arg1, [optional_arg], [*args])
-Lorem
+<a id="initialize"></a>
+### initialize([options={}])
+* **options**
+    * **renderItems** see [renderItems](#renderItems)
+    * **itemView** see [itemView](#itemView)
+    * **filterer** automatically calls [filter](#filter) if set
+    * all [View](./Chaplin.View.md#initialize) and standard
+    [Backbone.View](http://backbonejs.org/#View-constructor) options
 
+<a id="filter"></a>
+### filter([filterer, [filterCallback]])
+* **function filterer (see below)**
+* **function filterCallback (see below)**
 
-### method2()
-Lorem
+  Calling `filter` directly with a `filterer` and `filterCallback` overrides
+  the CollectionView's instance variables with these arguments.
 
+  Called with no arguments is a no-op
+
+<a id="filterer"></a>
+### filterer(item, index)
+* **Model item**
+* **int index of ***item*** in collection**
+* **returns boolean: is item included?**
+
+  A iterator function that determines which items are shown. Can be passed
+  in during instantiation via `options`. The function is optional; if not
+  set all items will be included.
+
+```coffeescript
+filterer: (item, index) ->
+  item.get 'color' is 'red'
+
+...
+
+filterer: (item, index) ->
+  index < 20 if @limit? else true
+
+```
+
+<a id="filterCallback"></a>
+### filterCallback(view, included)
+* **View view**
+* **boolean included**
+
+  Called on each item in the collection during filtering
+
+  Default is to hide excluded views
+
+```coffeescript
+filterCallback: (view, included) ->
+  view.$el.toggleClass('active', included)
+
+...
+
+filterCallback: (view, included) ->
+  opts = if included then 'long-title, large-thumbnail' else 'short-title, small-thumbnail'
+  view.showExtendedOptions(opts)
+```
+
+<a id="addCollectionListeners"></a>
+### addCollectionListeners()
+
+  By default adds event listeners for `add`, `remove`, and `reset` events. Can
+  be extended to track more events.
+
+<a id="getItemViews"></a>
+### getItemViews()
+
+  Returns a hash of views, keyed by their `cid` property
+
+<a id="renderAllItems"></a>
+### renderAllItems()
+
+  Render and insert all items in collection, triggering `visibilityChange` event
+
+<a id="renderAndInsertItem"></a>
+### renderAndInsertItem(item, index)
+* **Model item**
+* **int index**
+
+  a composite of [`@renderItem()`](#renderItem) and [`@insertView()`](#insertView)
+
+<a id="renderItem"></a>
+### renderItem(item)
+* **Model item**
+
+  Instantiate and render the view for an item using the `viewsByCid`
+  hash as a cache.
+
+<a id="getView"></a>
+### getView(model)
+* **Model model**
+
+  Returns an instance of the view class (as determined by `@itemView`).
+  Override this method to use several item view constructors depending
+  on the model type or data.
+
+<a id="insertView"></a>
+### insertView(item, view, [index], [enableAnimation])
+* **Model item**
+* **View view**
+* **int index (if unset will search through collection)**
+* **boolean enableAnimation (default true)**
+
+  Inserts a view into the list at the proper position, runs the `@filterer`
+  function.
+
+<a id="removeViewForItem"></a>
+### removeViewForItem(item)
+* **Model item**
+
+  Remove the view for an item, triggering a `visibilityChange` event
+
+<a id="updateVisibleItems"></a>
+### updateVisibleItems(item, [includedInFilter], [triggerEvent])
+* **Model item**
+* **boolean includedInFilter**
+* **triggerEvent (default true)**
+
+  Update visibleItems list and trigger a `visibilityChanged` event
+  if an item changed its visibility
 
 
 ## Usage
+  Most inheriting classes of CollectionView should be very small, with
+  the majority of implementations only needing to overwrite the itemView
+  property. Standard View conventions like adding `@modelBind` handlers
+  should still take place in `initialize`, but the majority of Collection-
+  specific logic is handled by this class.
+
+```coffeescript
+class LikesView extends CollectionView
+  tagname: 'ul'
+  className: 'likes-list'
+  itemView: LikeView
+  autoRender: true
+```
+
+### Examples
+
+  * [osti.io PostsView](https://github.com/paulmillr/ostio/blob/master/app/views/post/posts-view.coffee)
+  * [Facebook LikesView](https://github.com/chaplinjs/facebook-example/blob/master/coffee/views/likes_view.coffee)
+  * [FarmTab CustomersView](https://github.com/akre54/FT/blob/master/app/views/customers_collection_view.coffee)
 
 
 ## [Code](https://github.com/chaplinjs/chaplin/blob/master/src/chaplin/views/collection_view.coffee)

--- a/docs/chaplin.controller.md
+++ b/docs/chaplin.controller.md
@@ -12,12 +12,12 @@ Chaplin.Controller doesn't provide public methods. See the usage below:
 
 By default, all controllers must be placed into the `/controllers/` (the / stands for the root of the baseURL you have defined for your loader) folder and be suffixed with `_controller`. So for instance, the `LikeController` will be in the file `/controllers/like_controller.js`.
 
-If you want to overwrite this behaviour, you can edit the `controller_path` and `controller_suffix` options in the options hash you pass to `Chaplin.Application.initDispatcher` or `Chaplin.Dispatcher.initialize`. See details in the `Chaplin.Dispatcher` [documentation](/docs/dispatcher.html#initialize).
+If you want to overwrite this behaviour, you can edit the `controller_path` and `controller_suffix` options in the options hash you pass to `Chaplin.Application.initDispatcher` or `Chaplin.Dispatcher.initialize`. See details in the `Chaplin.Dispatcher` [documentation](./chaplin.dispatcher.md#initialize).
 
 
 ### Structure
 
-By convention, there is a controller for each application module. A controller may provide several action methods like `index`, `show`, `edit` and so on. These actions are called by the [Chaplin.Dispatcher](/docs/dispatcher.html) when a route matches.
+By convention, there is a controller for each application module. A controller may provide several action methods like `index`, `show`, `edit` and so on. These actions are called by the [Chaplin.Dispatcher](./chaplin.dispatcher.md) when a route matches.
 
 Most of the time, a controller is started following a route match. In this case, the URL representing the application state is already given. But a controller can also be started programatically by publishing a `!startupController` event. In this case, the URL has to be determined. This is the purpose of the `historyURL` method.
 

--- a/docs/chaplin.event_broker.md
+++ b/docs/chaplin.event_broker.md
@@ -1,6 +1,6 @@
 # Chaplin.EventBroker
 
-The EventBroker offer an interface to interact with [Chaplin.mediator](/docs/mediator.html). As of Backbone 0.9.2, the broker just serves the purpose that a handler cannot be registered twice for the same event.
+The EventBroker offer an interface to interact with [Chaplin.mediator](./chaplin.mediator.md). As of Backbone 0.9.2, the broker just serves the purpose that a handler cannot be registered twice for the same event.
 
 ## Methods of `Chaplin.EventBroker`
 

--- a/docs/chaplin.layout.md
+++ b/docs/chaplin.layout.md
@@ -6,7 +6,7 @@
 
 <a name="initialize"></a>
 
-### initialize( [options={}] )
+### initialize([options={}])
 
 * **options**:
     * **routeLinks**: the selector of elements you want to apply internal routing to. Set to false to deactivate internal routing. *Default: 'a, .go-to'*
@@ -15,14 +15,14 @@
         * function: check the return value. Return `true` to continue routing, return `false` to stop routing. The path and the elements are passed as parameters. Example: `function(href, el) { return href == 'bla'; }`
         * false: never skip routing
     Default: '.noscript'*. That is, you can add a `noscript` class to internal links to prevent routing by the Chaplin application.
-    * **openExternalToBlank**: wheter or not links to external domains should open in a new window/tab. *Default: false*
+    * **openExternalToBlank**: whether or not links to external domains should open in a new window/tab. *Default: false*
     * **scrollTo**: the coordinates (x, y) you want to scroll to on view replacement. Set to *false* to deactivate it. *Default: [0, 0]*
     * **titleTemplate**: a function which returns the document title. Per default, it gets a object passed with the properties `title` and `subtitle`. *Default: _.template("<%= subtitle %> - <%= title %>")*
 
 
 <a name="delegateEvents"></a>
 
-### delegateEvents( [events] )
+### delegateEvents([events])
 
 A wrapper for `Backbone.View.delegateEvents`. See Backbone [documentation](http://backbonejs.org/#View-delegateEvents) for more details.
 
@@ -31,33 +31,33 @@ A wrapper for `Backbone.View.delegateEvents`. See Backbone [documentation](http:
 
 ### undelegateEvents()
 
-A wrapper for `Backbone.View.delegateEvents`. See Backbone [documentation](http://backbonejs.org/#View-undelegateEvents) for more details.
+A wrapper for `Backbone.View.undelegateEvents`. See Backbone [documentation](http://backbonejs.org/#View-undelegateEvents) for more details.
 
 
 <a name="hideOldView"></a>
 
-### hideOldView( controller )
+### hideOldView(controller)
 
 Hide the active (old) view on the `beforeControllerDispose` event sent by the dispatcher on route change and scroll to the coordinates specified by the initialize `scrollTo` option.
 
 
 <a name="showNewView"></a>
 
-### showNewView( context )
+### showNewView(context)
 
 Show the new view on the `startupController` event sent by the dispatcher on route change.
 
 
 <a name="adjustTitle"></a>
 
-### adjustTitle( context )
+### adjustTitle(context)
 
 Adjust the title of the page base on the `titleTemplate` option. The `title` variable is the one defined at the application level and the `subtitle` the one at the controller level.
 
 
 <a name="openLink"></a>
 
-### openLink( event )
+### openLink(event)
 
 Open the `href` or `data-href` URL of a DOM element. When `openLink` is called it checks if the `href` is valid and runs the `skipRouting` functin if set by the user. If the href valid, it checks if it is an external link and depending on the `openExternalToBlank` option, opens it in a new window. Finally, if it is an internal link, it starts routing the URL.
 

--- a/docs/chaplin.mediator.md
+++ b/docs/chaplin.mediator.md
@@ -3,7 +3,7 @@ As all modules are encapsulated and independent from each other, we need a way t
 
 To inform other modules that something happened, a module doesn’t send messages directly (i.e. calling methods of specific objects). Instead, it publishes a message to the mediator without having to know who is listening. Other application modules might subscribe to these messages and react upon them.
 
-Note: If you want to give Pub/Sub functionality to a Class, also look at the [Subscriber](subscriber.md).
+Note: If you want to give Pub/Sub functionality to a Class, also look at the [Subscriber](./chaplin.subscriber.md).
 
 
 ## Methods of `Chaplin.mediator`

--- a/docs/chaplin.model.md
+++ b/docs/chaplin.model.md
@@ -16,7 +16,7 @@ Creates a new [jQuery Deferred object](http://api.jquery.com/category/deferred-o
 
 ### initSyncMachine
 
-Creates a new [Chaplin.SyncMachine](./syncmachine.html) instance.
+Creates a new [Chaplin.SyncMachine](./chaplin.sync_machine.md) instance.
 
 
 <a name="getAttributes"></a>

--- a/docs/chaplin.route.md
+++ b/docs/chaplin.route.md
@@ -34,7 +34,7 @@ Tests if the route matches a path and applies any parameter constraints.  This i
 
 ### handler([path], [options])
 
-The handler is called by Backbone.History when the route is matched.  It is also called by [Router#route](/docs/router.html#routepath) and passes `changeURL: true` as an option.
+The handler is called by Backbone.History when the route is matched.  It is also called by [Router#route](./chaplin.router.md#routepath) and passes `changeURL: true` as an option.
 
 * **path**: the matched path
 * **options**: an optional object
@@ -70,8 +70,8 @@ Extracts the parameters from the query string.
 
 ## Usage
 
-A new instance of `Chaplin.Route` is created for each route in the routes file of your application.  This occurs when the [match method](/docs/router.html#matchpattern-target-options) of `Chaplin.Router` is called. The actual routes file should be in the root of your project along with your main application bootstrapper file.
+A new instance of `Chaplin.Route` is created for each route in the routes file of your application.  This occurs when the [match method](./router.md#matchpattern-target-options) of `Chaplin.Router` is called. The actual routes file should be in the root of your project along with your main application bootstrapper file.
 
-The routes file is basically a module that returns an anonymous function in which the [match method](/docs/router.html#matchpattern-target-options) is passed in as an argument.
+The routes file is basically a module that returns an anonymous function in which the [match method](./chaplin.router.md#matchpattern-target-options) is passed in as an argument.
 
 ## [Code](https://github.com/chaplinjs/chaplin/blob/master/src/chaplin/lib/route.coffee)

--- a/docs/chaplin.router.md
+++ b/docs/chaplin.router.md
@@ -125,7 +125,7 @@ Handler for the globalized `!router:changeURL` event.  Calls `@changeURL`.
 Stops the Backbone.history instance and removes it from the Router object.  Also unsubscribes any events attached to the Router.  Attempts to freeze the Router to prevent any changes to the Router. See [Object.freeze](https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Object/freeze).
 
 ## Usage
-The Chaplin Router is a dependancy of [Chaplin.Application](./application.html) which should be extended from by your main application class. Within your application class you should initialize the Router by calling `@initRouter` passing your routes module as an argument.
+The Chaplin Router is a dependancy of [Chaplin.Application](./chaplin.application.md) which should be extended from by your main application class. Within your application class you should initialize the Router by calling `@initRouter` passing your routes module as an argument.
 
 ```coffeescript
 define [

--- a/docs/chaplin.support.md
+++ b/docs/chaplin.support.md
@@ -13,6 +13,7 @@ Determines if `Object.defineProperty` is supported. It's important to note that 
 
 ## Usage
 
-Support is used for feature detection and will return a boolean weather or not eh feature is detected.
+`Support` is used for feature detection and each method returns a boolean
+indicating feature support.
 
 ## [Code](https://github.com/chaplinjs/chaplin/blob/master/src/chaplin/lib/support.coffee)

--- a/docs/chaplin.utils.md
+++ b/docs/chaplin.utils.md
@@ -1,1 +1,72 @@
 # Chaplin.utils
+
+Chaplin's utils provide common functions for use throughout the project.
+
+
+## beget
+* **returns beget function**
+
+A standard Javascript helper function that creates an object which
+delegates to another object. (see Douglas Crockford's *Javascript:
+The Good Parts* for more details). Uses [Object.create](https://developer.mozilla.org/en-US/docs/JavaScript/Reference/Global_Objects/Object/create)
+when available, and falls back to a polyfill if not present.
+
+## readonly(object, [*properties])
+* **returns true if successful, false if unsupported**
+
+Makes properties of **object** read-only so they cannot be overwritten
+if the current environment supports it.
+
+## wrapMethod(instance, name) ->
+* **Object instance**
+* **String name, property of instance**
+* **returns the wrapped method**
+
+Wrap a method in order to call the corresponding
+`after-` method automatically (e.g. `afterRender` or
+`afterInitialize`)
+
+Enables a much more complex classical heirarchy when instruction
+order is important
+
+```coffeescript
+bob =
+  show: -> 'one'
+  afterShow: -> 'two'
+
+bob.show() # 'one'
+utils.wrapMethod bob, 'show'
+bob.show() # 'one' 'two'
+```
+
+## Upcase(str)
+* **String str**
+* **returns upcased String**
+
+Ensure the first character of **str** is capitalized
+
+```coffeescript
+utils.upcase 'larry bird' # 'Larry bird'
+utils.upcase 'AIR'        # 'AIR'
+```
+
+## underscorize: (string) ->
+* **String string**
+* **returns underscorized String**
+
+Convert a camelCased string to an entirely lowercased, underscore-
+separated string. Each capital leter is considered the beginning
+of a word.
+
+```coffeescript
+utils.underscorize 'underScoreHelper' # under_score_helper
+```
+
+## modifierKeyPressed
+* **jQuery event**
+* **returns boolean**
+
+Looks at an event object to determine if the **shift**, **alt**,
+**ctrl**, or **meta** keys were pressed. Useful in link click
+handling (i.e. if you need ctrl-click or shift-click to open the
+link in a new window)

--- a/docs/chaplin.view.md
+++ b/docs/chaplin.view.md
@@ -10,7 +10,8 @@ In addition to Backbone’s `events` hash and the `delegateEvents` method, Chapl
 
 Also, `@model.bind()` should not be used directly. Chaplin has `@modelBind()` which forces the handler context so the handler can be removed automatically on view disposal. When using Backbone’s naked `bind`, you have to deregister the handler manually to clear the reference from the model to the view.
 
-### Features und purpose
+
+## Features und purpose
 
 - Rendering model data using templates in a conventional way
 - Robust and memory-safe model binding
@@ -18,51 +19,242 @@ Also, `@model.bind()` should not be used directly. Chaplin has `@modelBind()` wh
 - Creating subviews
 - Disposal which cleans up all subviews, model bindings and Pub/Sub events
 
-# Rendering: getTemplateFunction, render, …
+<a id="initialize"></a>
+### initialize(options)
+* **options (default: empty hash)**
+    * `autoRender` see [autoRender](#autoRender)
+    * `container` see [container](#container)
+    * `containerMethod` see [containerMethod](#containerMethod)
+    * all standard [Backbone constructor
+  options](http://backbonejs.org/#View-constructor) (`model`, `collection`,
+  `el`, `id`, `className`, `tagName` and `attributes`)
 
-Backbone.View
-DRY
-Your application has to provide a standard
+  `options` may be specific on the view class or passed to the constructor. Passing
+  in options during instantiation overrides the View prototype's defaults.
 
-render
-getTemplateFunction
-  Empty method which needs to return the compiled template function
-getTemplateData
-  used internally to prepare the model data for the template
+  Views must always call `super` from their `initialize` methods. Unlike
+  Backbone's initialize method, Chaplin's initialize is required to
+  create the instance's subviews and listen for model or collection disposal.
+
+<a id="rendering"></a>
+## Rendering: getTemplateFunction, render, …
+
+  Your application should provide a standard way of rendering DOM
+  nodes by creating HTML from templates and template data. Chaplin
+  provides `getTemplateFunction` and `getTemplateData` for this purpose.
+  
+  Set [`autorender`](#autoRender) to true to enable rendering upon
+  View instantiation. Will automatically append to a [`container`](#container)
+  if one is set, although the method of appending can be overriden
+  by setting the [`containerMethod`](#containerMethod) property
+  (to `html`, `before`, `prepend`, etc).
+
+<a id="getTemplateFunction"></a>
+### getTemplateFunction()
+* **function (throws error if not overriden)**
+
+  Core method that returns the compiled template function. Usually
+  set application-wide in a base view class.
+
+  A common implementation will take a passed in `template` string and return
+  a compiled template function (e.g. a Handlebars or Underscore template function).
+```coffeescript
+@template = require 'templates/comment_view'
+```
+or if using templates in the DOM
+```coffeescript
+@template = $('#comment_view_template').html()
+```
+
+if using Handlebars
+```coffeescript
+getTemplateFunction: ->
+  Handlebars.compile @template
+```
+or if using underscore templates
+```coffeescript
+getTemplateFunction: ->
+  _.template @template
+```
+
+  Packages like [Brunch With Chaplin](https://github.com/paulmillr/brunch-with-chaplin)
+  precompile the template functions to improve application performance
 
 
+<a id="getTemplateData"></a>
+### getTemplateData()
+* **function that returns Object (throws error if not overriden)**
 
-# Options for auto-rendering and DOM appending
+  Empty method which returns the prepared model data for the template. Should
+  be overriden by inheriting classes (often from model data).
 
-options may be specific on the model class or passed to the constructor
+```coffeescript
+getTemplateData: ->
+  @model.attributes
 
-autoRender
-  Boolean, default: false
-container
-  jQuery object or element, default: null
-containerMethod
-  String, jQuery object method, default: 'append'
+...
 
-# Model binding
+getTemplateData: ->
+  title: 'Winnetou'
+  author: 'Karl May'
 
-modelBind
-modelUnbind
-modelUnbindAll
+```
 
-# Subviews
+  often overriden in a base model class to intelligently pick out attributes
 
-subview (name, [view])
-removeSubview (nameOrView)
+<a id="render"></a>
+### render
+  By default calls the `templateFunction` with the `templateData` and sets the html
+  of the `$el`. Can be overriden in your base view if needed, though should be
+  suitable for the majority of cases.
+
+<a id="afterInitialize"></a>
+<a id="afterRender"></a>
+## afterInitialize and afterRender
+  Chaplin's utils provides a `wrapMethod` feature that facilitates creating complex
+  class heirarchies. In the default implementation, only `initialize` and `render` are
+  wrapped, giving the View `afterInitialize` and `afterRender` methods that are called
+  after the prototype chain has completed for their respective heirarchy.
+  
+  `afterInitialize` calls `render` if `autoRender` is true, and `afterRender` attaches
+  the View to its `container` element.
+
+<a id="DOM-options"></a>
+## Options for auto-rendering and DOM appending
+
+<a id="autoRender"></a>
+### autoRender
+* **Boolean, default: false**
+  
+  Specifies whether the the View's `render` method should be called when
+  a view is instantiated.
+
+<a id="container"></a>
+### container
+* **jQuery object, selector string, or element, default: null**
+  
+  A selector for the View's containg element into which the `$el`
+  will be rendered. The container must exist in the DOM.
+  
+  Set this property in a derived class to specify the container element.
+  Normally this is a selector string but it might also be an element or
+  jQuery object. View is automatically inserted into the container when
+  it’s rendered (in the `afterRender` method). As an alternative you
+  might pass a `container` option to the constructor.
+  
+  A container is often an empty element within a parent view.
+
+<a id="containerMethod"></a>
+### containerMethod
+* **String, jQuery object method (default: 'append')**
+  
+  Method which is used for adding the view to the DOM via the `container`
+  element. (Like jQuery’s `html`, `prepend`, `append`, `after`, `before` etc.)
+  
+## Event delegation
+<a id="delegate"></a>
+### delegate(eventType, [selector], handler)
+* **String eventType - jQuery DOM event, (e.g. 'click', 'focus', etc )**,
+* **String selector (optional, if not set will bind to the view's $el)**,
+* **function handler (automatically bound to `this`)**
+
+Backbone's `events` hash doesn't work well with inheritance, so
+Chaplin provides the `delegate` method for this purpose. `delegate`
+is a wrapper for jQuery's `@$el.on` method, and has the same
+method signature.
+
+```coffeescript
+# For events affecting the whole view:
+# delegate(eventType, handler)
+@delegate('click', @clicked)
+
+# For events only affecting an element or colletion of elements in the view, pass a selector:
+# delegate(eventType, selector, handler)
+@delegate('click', 'button.confirm', @confirm)
+```
+
+<a id="model-binding"></a>
+## Model binding
+Disposal-aware event binding. Binds to the view's `@model` or `@collection`.
+
+<a id="modelBind"></a>
+### modelBind(type, handler)
+* **String type - Backbone event type (e.g. 'change:title', 'error', etc )**
+* **function handler**
+
+  Listen for model events and call an appropriate handler. Ensures
+  events are only bound once per handler by calling [`modelUnbind`](#modelUnbind)
+  before binding.
+
+  A common pattern is to listen for the 'change' event and trigger
+  a render, or show error message for failed model validation
+
+```coffeescript
+class LikeView extends View
+  initialize: ->
+    @modelBind 'change' @render
+    @modelBind 'error' @showErrorMessage
+    super
+
+  showErrorMessage: (message) ->
+    @$('.errors').append(message)
+```
+
+<a id="modelUnbind"></a>
+### modelUnbind(type, handler)
+* **String type - Backbone event type (e.g. 'change:title', 'error', etc )**
+* **function handler**
+
+  Unbind a handler from a model event
+
+<a id="modelUnbindAll"></a>
+### modelUnbindAll()
+
+  Unbind all recorded model event handlers.
+
+<a id="pass"></a>
+### pass(attribute, selector)
+* **String attribute - corresponds to a field on the model**
+* **String selector - a jQuery selector, object, or element**
+
+  Simple one-way model-view binding (closing the gap on one of the
+  key differences between Backbone and other frameworks like Ember,
+  Angular, etc)
+
+  Pass changed attribute values to specific elements in the view
+  For form controls, the value is changed, otherwise the element
+  text content is set to the model attribute value.
+
+  Useful for form views and other forms of user input, or updating
+  individual parts of the View from changed attributes
+
+```coffeescript
+@pass 'email', 'input[name="email"]'
+@pass 'author', 'h2.author-name'
+```
+
+
+## Subviews
+
+### subview(name, [view])
+* **String name**,
+* **View view (when setting the subview)**
+  
+  Add a subview to the View to be referenced by `name`. Calling with just the
+  `name` argument will return the subview associated with that `name`.
+  
+  Subviews are not automatically rendered. This is often done in an
+  inheriting view (i.e. in [CollectionView](./chaplin.collection_view.md)
+  or your own PageView base class).
+
+### removeSubview(nameOrView)
+Remove the specified subview. Can be called with either the `name` associated with the subview, or a reference to the subview instance.
 
 # Publish/Subscribe
 
-The View includes the EventBroker mixin
-Publish/Subscribe using the mediator
+The View includes the [EventBroker](./chaplin.event_broker.md) mixin
+Publish/Subscribe using the [mediator](./chaplin.mediator.md)
 
 subscribeEvent (type:String, handler:Function):mediator
 unsubscribeEvent (type:String, handler:Function):mediator
 unsubscribeAllEvents ():mediator
-
-### method1(arg1, [optional_arg], [*args])
-
-Lorem

--- a/docs/events.md
+++ b/docs/events.md
@@ -8,7 +8,7 @@ For models and views, there are several wrapper methods for event handler regist
 
 In models and views, there is a shortcut for subscribing to global events:
 
-```
+```coffeescript
 @subscribeEvent 'login', @doSomething
 ```
 
@@ -20,7 +20,7 @@ The `subscribeEvent` method has a counterpart `unsubscribeEvent`. These mehods a
 
 In views, the standard `@model.bind` way to register a handler for a model event should not be used. Use the memory-saving wrapper `modelBind` instead:
 
-```
+```coffeescript
 @modelBind 'add', @doSomething
 ```
 
@@ -28,7 +28,7 @@ In a model, it’s fine to use `bind` directly as long as the handler is a metho
 
 A view also provides `modelUnbind` and `modelUnbindAll` for deregistering. The latter is called automatically on view disposal.
 
-```
+```coffeescript
 @modelUnbind 'add', @doSomething
 ```
 
@@ -38,7 +38,7 @@ Most views handle user input by listening to DOM events. Backbone provides the `
 
 Chaplin’s `View` class provides the `delegate` method as a shortcut for `@$el.on`. It has the same signature as the jQuery 1.7 `on` method. Some examples:
 
-```
+```coffeescript
 @delegate 'click', '.like-button', @like
 @delegate 'click', '.close-button', @skip
 ```
@@ -47,7 +47,7 @@ Chaplin’s `View` class provides the `delegate` method as a shortcut for `@$el.
 
 In addition, `delegate` automatically binds the handler to the view object, so `@`/`this` points to the view. This means `delegate` creates a wrapper function which acts as the handler. As a consequence, it’s currently not possible to unbind a specific handler. Please use `@$el.off` directly to unbind all handlers for an event type for a selector:
 
-```
+```coffeescript
 @$el.off 'click', '.like-button'
 @$el.off 'click', '.close'
 ```

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -16,7 +16,7 @@ The boilerplate comes in two flavours:
 - [CoffeeScript code](https://github.com/chaplinjs/chaplin-boilerplate), if you develop your application in CoffeeScript
 - [Plain JavaScript code](https://github.com/chaplinjs/chaplin-boilerplate-plain), if you develop your application in normal JavaScript
 
-Download the using git:
+Download the boilerplate using git:
 
 ```
 git archive --remote=https://github.com/chaplinjs/chaplin-boilerplate.git  HEAD

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -52,7 +52,7 @@ match 'likes/:id', 'likes#show'
 
 This works much like the [Ruby on Rails counterpart](http://guides.rubyonrails.org/routing.html). If a route matches, a `matchRoute` event is published passing a `params` hash which contains pattern matches (like `id` in the example above) and additional GET parameters.
 
-[Learn more about the Router](router.html)
+[Learn more about the Router](./chaplin.router.md)
 
 ### Dispatcher
 
@@ -66,7 +66,7 @@ mediator.publish '!startupController', 'controller', 'action', params
 
 The `Dispatcher` handles the `!startupController` event.
 
-[Learn more about the Dispatcher](dispatcher.html)
+[Learn more about the Dispatcher](./chaplin.dispatcher.md)
 
 ### Layout
 
@@ -74,7 +74,7 @@ The `Layout` is the top-level application view. When a new controller was activa
 
 In addition, the `Layout` handles the activation of internal links. That is, you can use a normal `<a href="/foo">` element to link to another application module.
 
-[Learn more about the Layout](layout.html)
+[Learn more about the Layout](./chaplin.layout.md)
 
 ### Controllers
 
@@ -82,13 +82,13 @@ A controller is the place where a model and associated views are instantiated. T
 
 By convention, there is a controller for each application module. A controller may provide several action methods like `index`, `show`, `edit` and so on. These actions are called by the `Dispatcher` when a route matches.
 
-[Learn more about controllers](controller.html)
+[Learn more about controllers](./chaplin.controller.md)
 
 ### Mediator
 
 The mediator is an event broker that implements the [Publish/Subscribe](http://en.wikipedia.org/wiki/Publish/Subscribe) design pattern. It should be used for most of the inter-module communication in Chaplin applications. Modules can emit events using `mediator.publish` in order to notify other modules, and listen for such events using `mediator.subscribe`. The mediator can also be used for sharing data between several modules easily, like a user model or other persistent and globally accessible data.
 
-[Learn more about the mediator](mediator.html)
+[Learn more about the mediator](./chaplin.mediator.md)
 
 ## Memory Management and Object Disposal
 
@@ -96,6 +96,6 @@ One of the core concerns of the Chaplin architecture is a proper memory manageme
 
 Backbone provides little out of the box so Chaplin ensures that every controller, model, collection and view cleans up after itself. Chaplin extends the Model, Collection and View classes of Chaplin to implement a powerful disposal process.
 
-[Learn more about disposal](disposal.html)
+[Learn more about disposal](./disposal.md)
 
 ![Ending](http://s3.amazonaws.com/imgly_production/3362023/original.jpg)

--- a/src/chaplin/views/view.coffee
+++ b/src/chaplin/views/view.coffee
@@ -64,6 +64,8 @@ define [
       # Call Backbone’s constructor
       super
 
+    # Inheriting classes must call `super` in their `initialize` method to
+    # properly inflate subviews and set up options
     initialize: (options) ->
       # No super call here, Backbone’s `initialize` is a no-op
 


### PR DESCRIPTION
This is a work in progress to update some of the View documentation. Would be great to get some feedback as its updated.

Couple questions that came up as I was looking over source:
- Should `wrapMethod` get moved to the utils file? it's not specific to View and could be useful elsewhere
- Can the extended view options logic (see #267) and subview assignment get moved from `initialize` to the `constructor`? Views are required to have subviews or they won't dispose correctly (#191, #192, #199, #260), but not every view needs model-view disposal binding.
