### PR TITLE
On serialization, also protect nested models by using delegator objects....

### DIFF
--- a/test/spec/model_spec.coffee
+++ b/test/spec/model_spec.coffee
@@ -1,9 +1,10 @@
 define [
   'underscore'
+  'backbone'
   'chaplin/mediator'
   'chaplin/models/model'
   'chaplin/lib/event_broker'
-], (_, mediator, Model, EventBroker) ->
+], (_, Backbone, mediator, Model, EventBroker) ->
   'use strict'
 
   describe 'Model', ->
@@ -12,7 +13,7 @@ define [
     model = null
 
     beforeEach ->
-      model = new Model id: 1, foo: 'foo'
+      model = new Model id: 1
 
     afterEach ->
       model.dispose()
@@ -32,63 +33,119 @@ define [
       expect(model.getAttributes()).to.be model.attributes
 
     it 'should serialize the attributes', ->
-      model1 = model
-      model2 = new Model
-        id: 2
-        bar: 'bar'
-      model3 = new Model
-        id: 3
-        qux: 'qux'
-      model4 = new Model
-        id: 4
-        foo: 'foo'
-      model5 = new Model
-        id: 5
-        baz: 'baz'
+      model1 = model.set number: 'one'
+      model2 = new Model id: 2, number: 'two'
+      model3 = new Model id: 3, number: 'three'
+      model4 = new Model id: 4, number: 'four'
+      model5 = new Model id: 5, number: 'five'
       collection = new Backbone.Collection [model4, model5]
-      model1.set model2: model2
-      model2.set model3: model3
+      model1.set {model2}
+      model2.set {model3}
       model2.set {collection}
-      model2.set model2: model2 # Circular fun!
-      model3.set model2: model2 # Even more fun!
+      model2.set {model2} # Circular fun!
+      model3.set {model2} # Even more fun!
+      model4.set {model2} # Even more fun!
+
+      # Reference tree:
+      # model1
+      #   model2
+      #     model3
+      #       model2
+      #     collection
+      #       model4
+      #         model2
+      #       model5
+      #     model2
 
       actual = model.serialize()
 
       expected =
-        foo: 'foo'
+        id: 1
+        number: 'one'
         model2:
-          bar: 'bar'
+          id: 2
+          number: 'two'
           # Circular references are nullified
           model2: null
           model3:
-            qux: 'qux'
+            id: 3
+            number: 'three'
             # Circular references are nullified
             model2: null
           collection: [
-            {foo: 'foo'},
-            {baz: 'baz'}
+            {
+              id: 4
+              number: 'four'
+              # Circular references are nullified
+              model2: null
+            },
+            {
+              id: 5
+              number: 'five'
+            }
           ]
 
-      #console.debug 'passedTemplateData', d
-
       expect(actual).to.be.an 'object'
-      expect(actual.foo).to.be expected.foo
+      expect(actual.number).to.be expected.number
 
       expect(actual.model2).to.be.an 'object'
-      expect(actual.model2.bar).to.be expected.model2.bar
+      expect(actual.model2.number).to.be expected.model2.number
       expect(actual.model2.model2).to.be expected.model2.model2
 
-      expect(actual.model2.collection).to.be.an 'array'
-      expect(actual.model2.collection[0].foo).to.be(
-        expected.model2.collection[0].foo
-      )
-      expect(actual.model2.collection[1].baz).to.be(
-        expected.model2.collection[1].baz
-      )
+      actualCollection = actual.model2.collection
+      expectedCollection = expected.model2.collection
+      expect(actualCollection).to.be.an 'array'
+      expect(actualCollection[0].number).to.be expectedCollection[0].number
+      expect(actualCollection[0].model2).to.be expectedCollection[0].model2
+      expect(actualCollection[1].number).to.be expectedCollection[1].number
 
       expect(actual.model2.model3).to.be.an 'object'
-      expect(actual.model2.model3.qux).to.be expected.model2.model3.qux
+      expect(actual.model2.model3.number).to.be expected.model2.model3.number
       expect(actual.model2.model3.model2).to.be expected.model2.model3.model2
+
+    it 'should protect the original attributes when serializing', ->
+      model1 = model.set number: 'one'
+      model2 = new Model id: 2, number: 'two'
+      model3 = new Backbone.Model id: 3, number: 'three'
+      model1.set {model2}
+      model1.set {model3}
+
+      serialized = model1.serialize()
+      # Try to tamper with the model attributes
+      serialized.number = 'new'
+      serialized.model2.number = 'new'
+      serialized.model3.number = 'new'
+
+      # Original attributes remain unchanged
+      expect(model1.get('number')).to.be 'one'
+      expect(model2.get('number')).to.be 'two'
+      expect(model3.get('number')).to.be 'three'
+
+    it 'should serialize nested Backbone models and collections', ->
+      model1 = model.set number: 'one'
+      model2 = new Model id: 2, number: 'two'
+      model3 = new Backbone.Model id: 3, number: 'three'
+      collection = new Backbone.Collection [
+        new Model id: 4, number: 'four'
+        new Backbone.Model id: 5, number: 'five'
+      ]
+
+      model1.set {model2}
+      model1.set {model3}
+      model1.set {collection}
+
+      actual = model1.serialize()
+
+      expect(actual.number).to.be 'one'
+      expect(actual.model2).to.be.an 'object'
+      expect(actual.model2.number).to.be 'two'
+      expect(actual.model3).to.be.an 'object'
+      expect(actual.model3.number).to.be 'three'
+
+      expect(actual.collection).to.be.an 'array'
+      expect(actual.collection.length).to.be 2
+      expect(actual.collection[0].number).to.be 'four'
+      expect(actual.collection[1].number).to.be 'five'
 
     it 'should dispose itself correctly', ->
       expect(model.dispose).to.be.a 'function'


### PR DESCRIPTION
... Improve Backbone model support.

See #284. I don’t think this is absolutely necessary. For me this is an edge case, and it also has a small performance impact. But for consistency reasons, we might choose this way, so I prepared a PR for further discussion.

The basic change is to create a delegator object for nested models, too. Writing properties of the nested models in `getTemplateData` will create properties on the delegator and won’t modify the original model.

Of course, this isn’t a deep copy, so changing complex objects will still change the original model attributes.
