### PR TITLE
Add support for navigating by route reversal. Closes gh-292.

### DIFF
--- a/src/chaplin/lib/router.coffee
+++ b/src/chaplin/lib/router.coffee
@@ -24,6 +24,7 @@ define [
         pushState: true
 
       @subscribeEvent '!router:route', @routeHandler
+      @subscribeEvent '!router:routeByName', @routeByNameHandler
       @subscribeEvent '!router:reverse', @reverseHandler
       @subscribeEvent '!router:changeURL', @changeURLHandler
 
@@ -99,6 +100,17 @@ define [
 
       routed = @route path, options
       callback? routed
+
+    routeByNameHandler: (name, params, callback) ->
+      # Support old signature: Assume only path and callback were passed
+      # if we only got two arguments
+      if arguments.length is 2 and typeof params is 'function'
+        callback = params
+        params = {}
+
+      path = @reverse name, params
+      return unless path
+      @routeHandler path, callback
 
     # Change the current URL, add a history entry.
     changeURL: (url, options = {}) ->

--- a/test/spec/router_spec.coffee
+++ b/test/spec/router_spec.coffee
@@ -364,6 +364,19 @@ define [
       expect(passedParams).to.be.an 'object'
       expect(passedOptions).to.eql {path, changeURL: true}
 
+    # Listening to the !router:routeByName event
+    # ------------------------------------------
+    it 'should listen to the !router:routeByName event', ->
+      router.match 'index', 'null#null', name: 'home'
+      router.match 'phoneparams/:one', 'phonebook#dial', name: 'phonebook'
+
+      routeSpy = sinon.spy router, 'route'
+
+      mediator.publish '!router:routeByName', 'phonebook', one: 145
+      expect(passedRoute.controller).to.be 'phonebook'
+      expect(passedRoute.action).to.be 'dial'
+      expect(passedOptions.path).to.be 'phoneparams/145'
+
     # Listening to the !router:changeURL event
     # ----------------------------------------
 


### PR DESCRIPTION
Usage:

``` coffeescript
# assuming there is route
match 'users/:login', 'users#show', name: 'showUser'

@publishEvent '!router:routeByName', 'showUser', login: 'paulmillr'
# same as
@publishEvent '!router:route', 'users/paulmillr'
```
