### PR TITLE
URL did not get adjusted when calling redirectTo in a beforeAction function

### DIFF
--- a/src/chaplin/dispatcher.coffee
+++ b/src/chaplin/dispatcher.coffee
@@ -180,8 +180,10 @@ define [
       # Save returned value and also immediately return in case the value is false
       next = (method) =>
         # Stop if the action triggered a redirect
-        return if controller.redirected
-
+        if controller.redirected
+          # Adjust the URL; pass in params
+          return @adjustURL controller, params, {}
+          
         # End of chain, finally start the action
         unless method
           return @executeAction args...


### PR DESCRIPTION
``` coffeescript
beforeAction: 
  '.*': -> 
    unless Chaplin.mediator.user
      @redirectTo '!/sign-in'
```

I was really excited to test out the new beforeAction functionality today since my own home-grown solutions to this problem have not been ideal. I figured the redirectTo function should adjust the URL when redirecting, so I went ahead and fixed it.
