### PR TITLE
Replace `Controller#title` property with `Controller#adjustTitle`.

### DIFF
--- a/src/chaplin/controllers/controller.coffee
+++ b/src/chaplin/controllers/controller.coffee
@@ -32,6 +32,9 @@ define [
     initialize: ->
       # Empty per default
 
+    adjustTitle: (subtitle) ->
+      @publishEvent '!adjustTitle', subtitle
+
     # Redirection
     # -----------
 

--- a/src/chaplin/views/layout.coffee
+++ b/src/chaplin/views/layout.coffee
@@ -45,7 +45,7 @@ define [
 
       @subscribeEvent 'beforeControllerDispose', @hideOldView
       @subscribeEvent 'startupController', @showNewView
-      @subscribeEvent 'startupController', @adjustTitle
+      @subscribeEvent '!adjustTitle', @adjustTitle
 
       # Set the app link routing
       if @settings.routeLinks
@@ -84,10 +84,8 @@ define [
     # Handler for the global startupController event
     # Change the document title to match the new controller
     # Get the title from the title property of the current controller
-    adjustTitle: (context) ->
-      title = @title or ''
-      subtitle = context.controller.title or ''
-      title = @settings.titleTemplate {title, subtitle}
+    adjustTitle: (subtitle = '') ->
+      title = @settings.titleTemplate {@title, subtitle}
 
       # Internet Explorer < 9 workaround
       setTimeout (-> document.title = title), 50

--- a/test/spec/layout_spec.coffee
+++ b/test/spec/layout_spec.coffee
@@ -79,7 +79,7 @@ define [
       expect($el.css('visibility')).to.be 'visible'
 
     it 'should set the document title', (done) ->
-      mediator.publish 'startupController', startupControllerContext
+      mediator.publish '!adjustTitle', testController.title
       setTimeout ->
         title = "#{testController.title} \u2013 #{layout.title}"
         expect(document.title).to.be title


### PR DESCRIPTION
So, the question is: should we remove support of `Controller#title` at all? Maybe we should replace it with `Controller#adjustTitle` which will emit the event and promote it more? (i’m scared about idea of non-incapsulated `!adjustTitle`)
