### PR TITLE
Fix bug with "events" and "beforeAction" hashes in loops where getPrototypeChain() is used

### DIFF
--- a/src/chaplin/dispatcher.coffee
+++ b/src/chaplin/dispatcher.coffee
@@ -164,6 +164,8 @@ define [
         # Iterate over the before actions in search for a matching
         # name with the arguments’ action name
         for name, beforeAction of prototype.beforeAction
+          # Do not add this object more than once
+          continue if _.indexOf(beforeActions, beforeAction) >= 0
           if name is action or RegExp("^#{name}$").test(action)
             if typeof beforeAction is 'string'
               beforeAction = controller[beforeAction]

--- a/src/chaplin/views/view.coffee
+++ b/src/chaplin/views/view.coffee
@@ -159,8 +159,11 @@ define [
     # of the parent view if it exists.
     delegateEvents: ->
       @undelegateEvents()
-      for proto in utils.getPrototypeChain this when proto.events?
-        @_delegateEvents proto.events
+      events = []
+      for proto in utils.getPrototypeChain this
+        events.push proto.events if proto.events and _.indexOf(events, proto.events) < 0
+      for eventsHash in events
+        @_delegateEvents eventsHash
       return
 
     # Remove all handlers registered with @delegate.

--- a/test/spec/view_spec.coffee
+++ b/test/spec/view_spec.coffee
@@ -220,13 +220,13 @@ define [
 
       delay ->
         for index in _.range(1, 5)
-          expect(d["a#{index}Handler"]).was.called()
+          expect(d["a#{index}Handler"]).was.calledOnce()
         for index in bcd
           expect(d["#{index}Handler"]).was.notCalled()
           d.click(index)
         delay ->
           for index in bcd
-            expect(d["#{index}Handler"]).was.called()
+            expect(d["#{index}Handler"]).was.calledOnce()
           done()
 
     it 'should bind handlers to model events', ->


### PR DESCRIPTION
``` coffee
class A

class B extends A
  obj: foo: 'bar'

instance = new A

chain = require('chaplin/lib/utils').getPrototypeChain instance
for item in chain
  for proto of item
     # Access to proto.obj here will always work, despite `class A` not having one, therefore, duplication can arise in the loop for this case!
```

The proposed solution won't add `events`, nor `beforeActions` twice to the arrays, in case some extended class hasn't defined those objects in the prototype.
