### PR TITLE
Update collection view to listen to the new backbone 0.9.9 sort event

### DIFF
--- a/src/chaplin/views/collection_view.coffee
+++ b/src/chaplin/views/collection_view.coffee
@@ -110,7 +110,7 @@ define [
     addCollectionListeners: ->
       @listenTo @collection, 'add',    @itemAdded
       @listenTo @collection, 'remove', @itemRemoved
-      @listenTo @collection, 'reset',  @itemsResetted
+      @listenTo @collection, 'reset sort',  @itemsResetted
 
     # Rendering
     # ---------

--- a/test/spec/collection_view_spec.coffee
+++ b/test/spec/collection_view_spec.coffee
@@ -207,6 +207,20 @@ define [
       newView1 = collectionView.subview "itemView:#{model1.cid}"
       expect(newView1).to.be view1
 
+    it 'should reorder views on sort', ->
+      collection.reset addThree()
+
+      sortAndMatch = (comparator) ->
+        collection.comparator = comparator
+        collection.sort()
+        viewsMatchCollection()
+
+      # Explicity force a default sort to ensure two different sort orderings
+      sortAndMatch (a, b) -> a.id > b.id
+
+      # Reverse the sort order and test it
+      sortAndMatch (a, b) -> a.id < b.id
+
     it 'should insert views in the right order', ->
       m0 = new Model id: 0
       m1 = new Model id: 1


### PR DESCRIPTION
Before backbone 0.9.9   backbone triggered the reset event on collection.sort(), which either intended or unintended made it possible to reorder item views in collection views by sorting the collection.

With the addition of the sort event in 0.9.9 this is no longer possible - which is what this PR resolves.

Added a test to prove the case. 
