### PR TITLE
Remove collection.update since its provided by backbone

### DIFF
--- a/src/chaplin/models/collection.coffee
+++ b/src/chaplin/models/collection.coffee
@@ -40,44 +40,6 @@ define [
         @add model, options
       @trigger 'reset'
 
-    # Updates a collection with a list of models
-    # Just like the reset method, but only adds new items and
-    # removes items which are not in the new list.
-    # Fires individual `add` and `remove` event instead of one `reset`.
-    #
-    # options:
-    #   deep: Boolean flag to specify whether existing models
-    #         should be updated with new values
-    update: (models, options = {}) ->
-      fingerPrint = @pluck('id').join()
-      ids = _(models).pluck('id')
-      newFingerPrint = ids.join()
-
-      # Only remove if ID fingerprints differ
-      if newFingerPrint isnt fingerPrint
-        # Remove items which are not in the new list
-        _ids = _(ids) # Underscore wrapper
-        i = @models.length
-        while i--
-          model = @models[i]
-          unless _ids.include model.id
-            @remove model
-
-      # Only add/update list if ID fingerprints differ
-      # or update is deep (member attributes)
-      if newFingerPrint isnt fingerPrint or options.deep
-        # Add items which are not yet in the list
-        for model, i in models
-          preexistent = @get model.id
-          if preexistent
-            # Update existing model
-            preexistent.set model if options.deep
-          else
-            # Insert new model
-            @add model, at: i
-
-      return
-
     # Disposal
     # --------
 

--- a/test/spec/collection_spec.coffee
+++ b/test/spec/collection_spec.coffee
@@ -64,45 +64,6 @@ define [
       expect(addSpy).was.notCalled()
       expect(resetSpy).was.called()
 
-    it 'should update models', ->
-      expect(collection.update).to.be.a 'function'
-
-      collection.reset ({id: i} for i in [0..5])
-
-      addSpy = sinon.spy()
-      collection.on 'add', addSpy
-      removeSpy = sinon.spy()
-      collection.on 'remove', removeSpy
-      resetSpy = sinon.spy()
-      collection.on 'reset', resetSpy
-
-      newOrder = [1, 3, 5, 7, 9, 11]
-      collection.update ({id: i} for i in newOrder)
-      expectOrder newOrder
-
-      expect(addSpy.callCount).to.be 3
-      expect(removeSpy.callCount).to.be 3
-      expect(resetSpy).was.notCalled()
-
-    it 'should update models deeply', ->
-      collection.reset ({id: i, old1: true, old2: false} for i in [0..5])
-      newOrder = [1, 3, 5, 7, 9, 11]
-      models = ({id: i, old2: true, new: true} for i in newOrder)
-
-      collection.update models, deep: true
-      expectOrder newOrder
-
-      for id in [1, 3, 5]
-        model = collection.get id
-        expect(model.get('old1')).to.be true
-        expect(model.get('old2')).to.be true
-        expect(model.get('new')).to.be true
-      for id in [7, 9, 11]
-        model = collection.get id
-        expect(model.get('old1')).to.be undefined
-        expect(model.get('old2')).to.be true
-        expect(model.get('new')).to.be true
-
     it 'should serialize the models', ->
       model1 = new Model id: 1, foo: 'foo'
       model2 = new Backbone.Model id: 2, bar: 'bar'


### PR DESCRIPTION
Remove collection.update since its provided by backbone

Verified that all chaplin tests passed with backbone.collection before removing, as discussed in #328

closes  #328
