### PR TITLE
Backbone now exports what DOM manipulation library its bound to.

### DIFF
--- a/src/chaplin/views/collection_view.coffee
+++ b/src/chaplin/views/collection_view.coffee
@@ -1,9 +1,12 @@
 define [
-  'jquery'
+  'backbone'
   'underscore'
   'chaplin/views/view'
-], ($, _, View) ->
+], (Backbone, _, View) ->
   'use strict'
+
+  # Shortcut to access the DOM manipulation library
+  $ = Backbone.$
 
   # General class for rendering Collections.
   # Derive this class and declare at least `itemView` or override

--- a/src/chaplin/views/layout.coffee
+++ b/src/chaplin/views/layout.coffee
@@ -1,11 +1,13 @@
 define [
-  'jquery'
   'underscore'
   'backbone'
   'chaplin/lib/utils'
   'chaplin/lib/event_broker'
-], ($, _, Backbone, utils, EventBroker) ->
+], (_, Backbone, utils, EventBroker) ->
   'use strict'
+
+  # Shortcut to access the DOM manipulation library
+  $ = Backbone.$
 
   class Layout # This class does not extend View
 

--- a/src/chaplin/views/view.coffee
+++ b/src/chaplin/views/view.coffee
@@ -1,13 +1,15 @@
 define [
-  'jquery'
   'underscore'
   'backbone'
   'chaplin/lib/utils'
   'chaplin/lib/event_broker'
   'chaplin/models/model'
   'chaplin/models/collection'
-], ($, _, Backbone, utils, EventBroker, Model, Collection) ->
+], (_, Backbone, utils, EventBroker, Model, Collection) ->
   'use strict'
+
+  # Shortcut to access the DOM manipulation library
+  $ = Backbone.$
 
   class View extends Backbone.View
 


### PR DESCRIPTION
Backbone.$ is now a reference to jQuery / Zepto / etc.
