### PR TITLE
Changed addedToDOM event name to addedToParent inside the collection view.

### DIFF
--- a/src/chaplin/views/collection_view.coffee
+++ b/src/chaplin/views/collection_view.coffee
@@ -390,8 +390,8 @@ define [
             $previous = children.eq position - 1
             $previous.after viewEl
 
-      # Tell the view that it was added to the DOM
-      view.trigger 'addedToDOM'
+      # Tell the view that it was added to its parent.
+      view.trigger 'addedToParent'
 
       # Update the list of visible items, trigger a `visibilityChange` event
       @updateVisibleItems item, included


### PR DESCRIPTION
This closes #175 (at least I think it does). There is still an `addedToDOM` event fired by the view itself when it does the auto-attach to the DOM. But I think that one is warranted as it actually is attaching it to the DOM. 
