### PR TITLE
Make delegateEvents override take optional events hash

### DIFF
--- a/src/chaplin/views/view.coffee
+++ b/src/chaplin/views/view.coffee
@@ -158,8 +158,11 @@ module.exports = class View extends Backbone.View
 
   # Override Backbones method to combine the events
   # of the parent view if it exists.
-  delegateEvents: ->
+  delegateEvents: (events) ->
     @undelegateEvents()
+    if events
+      @_delegateEvents events
+      return
     for events in utils.getAllPropertyVersions this, 'events'
       @_delegateEvents events
     return


### PR DESCRIPTION
delegateEvents in backbone takes an optional events hash. By not allowing this in chaplin we make it impossible for plugins like backbone.stickit to work with chaplin.

I just made a quickfix - feel free to clean this fix up or give directions.
