### PR TITLE
Would it be possible to make name optional for @subview()?

### DIFF
--- a/src/chaplin/views/view.coffee
+++ b/src/chaplin/views/view.coffee
@@ -173,11 +173,15 @@ module.exports = class View extends Backbone.View
 
   # Getting or adding a subview
   subview: (name, view) ->
-    if name and view
+    if typeof name is not 'string'
+      view = name
+      name = null
+    if view
       # Add the subview, ensure it’s unique
-      @removeSubview name
+      if name
+        @removeSubview name
+        @subviewsByName[name] = view
       @subviews.push view
-      @subviewsByName[name] = view
       view
     else if name
       # Get and return the subview by the given name


### PR DESCRIPTION
For instance:

``` coffeescript
for model in items
  @subview(new MySubView({model:model, container: @$el.find(".container")})
```
