### PR TITLE
require underscore in Chaplin/Application.coffee

### DIFF
--- a/src/chaplin/application.coffee
+++ b/src/chaplin/application.coffee
@@ -1,5 +1,6 @@
 'use strict'
 
+_ = require 'underscore'
 Backbone = require 'backbone'
 mediator = require 'chaplin/mediator'
 Dispatcher = require 'chaplin/dispatcher'


### PR DESCRIPTION
`application.coffee` has an unintentional global `_` ([see #L19](https://github.com/chaplinjs/chaplin/blob/cf4530a14b3d0b7a9e36cef12a0edb2b30022a6a/src/chaplin/application.coffee#L19)).
