### PR TITLE
Declarative view bindings

### DIFF
--- a/test/spec/view_spec.coffee
+++ b/test/spec/view_spec.coffee
@@ -371,9 +371,9 @@ define [
           'ns:b mediator': 'b1Handler'
 
         initialize: ->
+          super
           @a1Handler = sinon.spy()
           @b1Handler = sinon.spy()
-          super
 
       class EventedView extends EventedViewParent
         listen:
@@ -395,9 +395,9 @@ define [
           'ns:b mediator': 'b2Handler'
 
         initialize: ->
+          super
           @a2Handler = sinon.spy()
           @b2Handler = sinon.spy()
-          super
 
       it 'should bind to own events declaratively', ->
         view = new EventedView model: new Model()


### PR DESCRIPTION
Views may have a `listen` object with declarative bindings to model, collection, mediator and itself. It works similar to Backbone.View’s `events` hash.

``` coffeescript
class View
  listen:
    # Listen to view events with @on
    'eventName': 'methodName'
    # Same as @listenTo @model, …
    'change:foo model': 'methodName'
    # Same as @listenTo @model, …
    'reset collection': 'methodName'
    # Same as @subscribeEvent …
    'pubSubEvent mediator': 'methodName'
    # The value can also be a function:
    'eventName': -> alert 'Hello!'
```

See #334 for previous discussions.
