### PR TITLE
Simplify sync machine.

### DIFF
--- a/src/chaplin/lib/sync_machine.coffee
+++ b/src/chaplin/lib/sync_machine.coffee
@@ -40,8 +40,8 @@ SyncMachine =
     if @_syncState in [SYNCING, SYNCED]
       @_previousSync = @_syncState
       @_syncState = UNSYNCED
-      @trigger @_syncState, this, @_syncState
-      @trigger STATE_CHANGE, this, @_syncState
+      @trigger @_syncState
+      @trigger STATE_CHANGE, @_syncState
     # when UNSYNCED do nothing
     return
 
@@ -49,8 +49,8 @@ SyncMachine =
     if @_syncState in [UNSYNCED, SYNCED]
       @_previousSync = @_syncState
       @_syncState = SYNCING
-      @trigger @_syncState, this, @_syncState
-      @trigger STATE_CHANGE, this, @_syncState
+      @trigger @_syncState
+      @trigger STATE_CHANGE, @_syncState
     # when SYNCING do nothing
     return
 
@@ -58,8 +58,8 @@ SyncMachine =
     if @_syncState is SYNCING
       @_previousSync = @_syncState
       @_syncState = SYNCED
-      @trigger @_syncState, this, @_syncState
-      @trigger STATE_CHANGE, this, @_syncState
+      @trigger @_syncState
+      @trigger STATE_CHANGE, @_syncState
     # when SYNCED, UNSYNCED do nothing
     return
 
@@ -67,8 +67,8 @@ SyncMachine =
     if @_syncState is SYNCING
       @_syncState = @_previousSync
       @_previousSync = @_syncState
-      @trigger @_syncState, this, @_syncState
-      @trigger STATE_CHANGE, this, @_syncState
+      @trigger @_syncState
+      @trigger STATE_CHANGE, @_syncState
     # when UNSYNCED, SYNCED do nothing
     return
 
@@ -77,9 +77,10 @@ SyncMachine =
 
 for event in [UNSYNCED, SYNCING, SYNCED, STATE_CHANGE]
   do (event) ->
-    SyncMachine[event] = (callback, context = this) ->
-      @on event, callback, context
-      callback.call(context) if @_syncState is event
+    eventName = event.charAt(0).toUpperCase() + event.slice(1)
+    SyncMachine["when#{eventName}"] = (callback) ->
+      @on event, callback, this
+      callback() if @_syncState is event
 
 # You’re frozen when your heart’s not open
 Object.freeze? SyncMachine

--- a/test/spec/sync_machine_spec.coffee
+++ b/test/spec/sync_machine_spec.coffee
@@ -37,12 +37,12 @@ define [
 
       machine.beginSync()
       expect(stateChange).was.calledOnce()
-      expect(stateChange).was.calledWith machine, 'syncing'
+      expect(stateChange).was.calledWith 'syncing'
       expect(syncing).was.calledOnce()
 
       machine.finishSync()
       expect(stateChange).was.calledTwice()
-      expect(stateChange).was.calledWith machine, 'synced'
+      expect(stateChange).was.calledWith 'synced'
       expect(synced).was.calledOnce()
 
     it 'should has shortcuts for checking sync state', ->
@@ -70,9 +70,9 @@ define [
       synced = sinon.spy()
       unsynced = sinon.spy()
 
-      machine.syncing syncing
-      machine.synced synced
-      machine.unsynced unsynced
+      machine.whenSyncing syncing
+      machine.whenSynced synced
+      machine.whenUnsynced unsynced
 
       machine.beginSync()
       expect(syncing).was.calledOnce()


### PR DESCRIPTION
1. Rename `machine.synced` etc methods to `machine.whenSynced`. This describes what methods do better. Also, methods will be companions to `isSynced` etc.
2. State change event will no longer receive “this” as second arg. Not sure why this was needed.
3. `synced`, `unsynced`, `syncing`, `unsynced` events will no longer receive “this” and current event name as args. Current event name in this case is superfluous.
4. `context` can no longer be passed to `when#{method}` methods as second arg. Use `_.bind` or `=>` for consistency.

Before:

``` coffeescript
model.synced => console.log 'Model is synced'
model.on 'syncStateChange', (model, eventName) =>
  console.log 'Model', model, 'had event', eventName
model.on 'synced', (model, eventName) =>
  console.log 'Model', model, 'was synced'
```

After:

``` coffeescript
model.whenSynced => console.log 'Model is synced'
model.on 'syncStateChange', (eventName) =>
  console.log 'Model', model, 'had event', eventName
model.on 'synced', =>
  console.log 'Model', model, 'was synced'
```
