### PR TITLE
Remove Collection#addAtomic.

### DIFF
--- a/src/chaplin/models/collection.coffee
+++ b/src/chaplin/models/collection.coffee
@@ -23,16 +23,6 @@ module.exports = class Collection extends Backbone.Collection
   serialize: ->
     @map utils.serialize
 
-  # Adds a collection atomically, i.e. throws no event until
-  # all members have been added
-  addAtomic: (models, options = {}) ->
-    return unless models.length
-    options.silent = true
-    direction = if typeof options.at is 'number' then 'pop' else 'shift'
-    while model = models[direction]()
-      @add model, options
-    @trigger 'reset'
-
   # Disposal
   # --------
 

--- a/test/spec/collection_spec.coffee
+++ b/test/spec/collection_spec.coffee
@@ -32,36 +32,6 @@ define [
         expect(typeof collection[method]).to.be 'function'
       expect(collection.state()).to.be 'pending'
 
-    it 'should add models atomically', ->
-      expect(collection.addAtomic).to.be.a 'function'
-
-      collection.reset ({id: i} for i in [0..2])
-
-      addSpy = sinon.spy()
-      collection.on 'add', addSpy
-      resetSpy = sinon.spy()
-      collection.on 'reset', resetSpy
-
-      collection.addAtomic ({id: i} for i in [3..5])
-      expectOrder [0, 1, 2, 3, 4, 5]
-
-      expect(addSpy).was.notCalled()
-      expect(resetSpy).was.called()
-
-    it 'should add models atomically at a specific position', ->
-      collection.reset ({id: i} for i in [0..2])
-
-      addSpy = sinon.spy()
-      collection.on 'add', addSpy
-      resetSpy = sinon.spy()
-      collection.on 'reset', resetSpy
-
-      collection.addAtomic ({id: i} for i in [3..5]), at: 1
-      expectOrder [0, 3, 4, 5, 1, 2]
-
-      expect(addSpy).was.notCalled()
-      expect(resetSpy).was.called()
-
     it 'should serialize the models', ->
       model1 = new Model id: 1, foo: 'foo'
       model2 = new Backbone.Model id: 2, bar: 'bar'


### PR DESCRIPTION
I’m not sure why we had this from day one even though we also had (and backbone now has) `update` method. @mehcode pointed that it would be cool to remove this.

Is this really useful?
