### PR TITLE
CollectionView#itemsResetted --> itemsReset

### DIFF
--- a/src/chaplin/views/collection_view.coffee
+++ b/src/chaplin/views/collection_view.coffee
@@ -114,7 +114,7 @@ module.exports = class CollectionView extends View
   addCollectionListeners: ->
     @listenTo @collection, 'add', @itemAdded
     @listenTo @collection, 'remove', @itemRemoved
-    @listenTo @collection, 'reset sort', @itemsResetted
+    @listenTo @collection, 'reset sort', @itemsReset
 
   # Rendering
   # ---------
@@ -162,7 +162,7 @@ module.exports = class CollectionView extends View
     @removeViewForItem item
 
   # When all items are resetted, render all anew
-  itemsResetted: =>
+  itemsReset: =>
     @renderAllItems()
 
   # Fallback message when the collection is empty


### PR DESCRIPTION
CollectionView's `itemsResetted` name always stuck out to me as grammatically awkward. I can tell that the name was meant to mirror the pattern of `itemAdded` and `itemRemoved` in that they are the past participle\* of the actions "add item" and "remove item" respectively, but the [past participle of "reset"](http://en.wiktionary.org/wiki/reset) is "reset", not "resetted".

Changing the phrasing to `itemsReset` introduces a little more abiguity in that we don't have the "-ed" suffix to help determine that it's not used as a present participle, but I think its proximity to `itemAdded` and `itemRemoved` should be clear enough.

*Yup, had to look this up
