### PR TITLE
Initial implementation of XHR request strategizing.

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -29,6 +29,7 @@ module.exports = (grunt) ->
     'temp/chaplin/lib/support.js'
     'temp/chaplin/lib/sync_machine.js'
     'temp/chaplin/lib/utils.js'
+    'temp/chaplin/lib/strategist.js'
     'temp/chaplin.js'
   ]
 

--- a/src/chaplin.coffee
+++ b/src/chaplin.coffee
@@ -14,4 +14,5 @@ module.exports =
   EventBroker:    require 'chaplin/lib/event_broker'
   support:        require 'chaplin/lib/support'
   SyncMachine:    require 'chaplin/lib/sync_machine'
+  Strategist:     require 'chaplin/lib/strategist'
   utils:          require 'chaplin/lib/utils'

--- a/src/chaplin/lib/strategist.coffee
+++ b/src/chaplin/lib/strategist.coffee
@@ -166,6 +166,9 @@ module.exports = class Strategist
           if handler
             @on "#{hook}:#{method}#{suffix}", _.bind handler, this, method
 
+    # Return nothing
+    return
+
   # The various stacks and queues used to facilitate the above.
   requests: null
 
@@ -184,11 +187,15 @@ module.exports = class Strategist
       abort: (method, options) ->
         # Abort a held request if we have one.
         @requests[method].abort() if @requests[method]
+
         # Wrap the callbacks so they won't be executed if we get disposed
         # without being aborted.
         if options
           for name in ['success', 'error', 'complete']
             options[name] = makeDisposable this, options[name]
+
+        # Return nothing
+        return
 
       stack: (method, options) ->
         # Wrap the callbacks so they won't be executed if we get disposed.
@@ -196,11 +203,15 @@ module.exports = class Strategist
           for name in ['success', 'error', 'complete']
             options[name] = makeDisposable this, options[name]
 
+        # Return nothing
+        return
+
     'sync:after':
       abort: (method, request) ->
         # Wrap the request object so that it could be diposed without being
         # aborted.
         request = new Disposable this, request
+
         # Store and return the request object for later abort.
         @requests[method] = request
 

--- a/src/chaplin/lib/strategist.coffee
+++ b/src/chaplin/lib/strategist.coffee
@@ -121,7 +121,7 @@ module.exports = class Strategist
   initialize: ->
     # Normalize the strategy object and apply defaults
     return if not @strategy or @strategy is 'null'
-    if _.isString @strategy
+    if typeof @strategy is 'string'
       # Strategy can be be declared to be universally abort or stack, etc.
       strategy = @strategy
       @strategy = {}
@@ -141,7 +141,7 @@ module.exports = class Strategist
 
     # Expands the strategy object into the full one with both hooks accessible.
     for hook in @hooks
-      if @strategy[hook] is null or _.isString @strategy[hook]
+      if @strategy[hook] is null or typeof @strategy[hook] is 'string'
         # This is being declared short-hand like `sync: 'abort'`.
         strategy = @strategy[hook]
         @strategy[hook] = {}

--- a/src/chaplin/lib/strategist.coffee
+++ b/src/chaplin/lib/strategist.coffee
@@ -211,7 +211,7 @@ module.exports = class Strategist
         requests.push request
         request = request.always =>
           requests = @requests[method]
-          requests[i..i] = [] if (i = _.indexOf(requests, request)) > -1
+          requests.splice _(requests).indexOf(request), 1
 
     'dispose':
       abort: (method) ->

--- a/src/chaplin/lib/strategist.coffee
+++ b/src/chaplin/lib/strategist.coffee
@@ -1,0 +1,244 @@
+'use strict'
+
+_ = require 'underscore'
+Backbone = require 'backbone'
+EventBroker = require 'chaplin/lib/event_broker'
+utils = require 'chaplin/lib/utils'
+
+# Strategist
+# ----------
+#
+# Add functionality to strategise the tracking of requests and disposal of
+# bound event handlers.
+#
+# There are two hooks and 3 strategies. These are a declarative method of
+# controlling asynchronous requests. To op-out of any such actions; declare
+# strategy to be null or 'null'.
+#
+# The first hook is on sync; the 3 strategies behave as follows:
+#  - 'stack'
+#    Allows concurrent requests but keeps track of them in a stack so they
+#    may be referenced later to perhaps abort in dispose.
+#
+#  - 'abort'
+#    requests are aborted as requests are made; only allows the last made
+#    request.
+#
+#  - 'null' or null
+#    Does nothing.
+#
+# The second hook is on disposal; the 2 strategies behave as follows:
+#  - 'abort'
+#    Aborts all pending requests (unless the sync hook was declared to be
+#    null in which case this does nothing).
+#
+#  - 'null', null, or 'stack'
+#    Does nothing (allows all pending requests to finish but in the case of
+#    'stack', does not execute callbacks)
+#
+# These strategies may be customized by hook, by request method, by
+# both, or at once.
+#
+# Abort all kinds of requests on both hooks.
+# strategy: 'abort'
+#
+# Abort only on reads but stack everything else.
+# strategy:
+#   read: 'abort'
+#   create: 'stack'
+#   update: 'stack'
+#   delete: 'stack'
+#
+# Do nothing; op-out of strategy:
+# strategy: null
+#
+# Abort on subsequent updates but don't abort the update in dispose.
+# strategy:
+#   update: 'abort'
+#   dispose:
+#     update: 'abort'
+
+# Wraps a method so that it will observe the disposed propety of an object
+# and silently execute (not calling its callback) if it is true.
+makeDisposable = (ref, callback) -> ->
+  return if ref.disposed
+  callback arguments... if callback
+
+# A request wrapper that observes an object that can be disposed. If the
+# request is disposed the request is still resolved but no callbacks are fired.
+class Disposable
+
+  # Does nothing but stores the request and the observed object reference.
+  constructor: (@ref, @request) ->
+
+  # Wrap every parameter which could be a function or an array of
+  # functions.
+  _wrap: (callbacks...) ->
+    result = []
+    for callback in callbacks
+      result.push if _.isArray callback
+        array = []
+        array.push makeDisposable @ref, item for item in callback
+        array
+      else
+        makeDisposable @ref, callback
+    result
+
+  # Forward the method and wrap the result for the request chaining methods.
+  done: -> new Disposable @ref, @request.done (@_wrap arguments...)...
+  fail: -> new Disposable @ref, @request.fail (@_wrap arguments...)...
+  always: -> new Disposable @ref, @request.always (@_wrap arguments...)...
+  then: -> new Disposable @ref, @request.then (@_wrap arguments...)...
+  progress: -> new Disposable @ref, @request.progress (@_wrap arguments...)...
+
+  # Forward additional methods.
+  abort: -> @request.abort arguments...
+
+module.exports = class Strategist
+
+  # Borrow the static extend method from Backbone
+  @extend = Backbone.Model.extend
+
+  # Mixin Backbone events.
+  _(@prototype).extend Backbone.Events
+
+  # Hooks that this strategist acts upon.
+  hooks: ['sync', 'dispose']
+
+  # Operations that can affect the hook.
+  methods: ['read', 'create', 'update', 'delete', 'patch']
+
+  constructor: (options) ->
+    # Copy some options to instance properties
+    if options
+      _(this).extend _.pick options, [
+        'strategy'
+      ]
+
+    # Invoke initialize.
+    @initialize arguments...
+
+  initialize: ->
+    # Normalize the strategy object and apply defaults
+    return if not @strategy or @strategy is 'null'
+    if _.isString @strategy
+      # Strategy can be be declared to be universally abort or stack, etc.
+      strategy = @strategy
+      @strategy = {}
+      for method in @methods
+        @strategy[method] = strategy
+
+    # Normalize the handlers object so that inheritance will work correctly.
+    # This merges all derived handlers object into the handlers object for the
+    # base prototype.
+    for version in utils.getAllPropertyVersions this, 'handlers'
+      for hook of version
+        if @handlers[hook]
+          for strategy of version[hook] when not @handlers[hook][strategy]
+            @handlers[hook][strategy] = version[hook][strategy]
+        else
+          @handlers[hook] = version[hook]
+
+    # Expands the strategy object into the full one with both hooks accessible.
+    for hook in @hooks
+      if @strategy[hook] is null or _.isString @strategy[hook]
+        # This is being declared short-hand like `sync: 'abort'`.
+        strategy = @strategy[hook]
+        @strategy[hook] = {}
+        for method in @methods
+          @strategy[hook][method] = strategy
+      # If it is still undefined; define it as an empty object
+      @strategy[hook] or= {}
+      for method in @methods
+        @strategy[hook][method] or= @strategy[method] or 'null'
+
+        # Get the strategy; skipping the rest if it was no-op'd
+        strategy = @strategy[hook][method]
+        continue if strategy is null or strategy is 'null'
+
+        # Initialize the stacks as neccessary
+        @requests or= {}
+        @handlers.initialize[strategy].call this, method
+
+        # Register handlers to event listeners.
+        for suffix in ['', ':before', ':after']
+          handler = @handlers["#{hook}#{suffix}"]?[strategy]
+          if handler
+            @on "#{hook}:#{method}#{suffix}", _.bind handler, this, method
+
+  # The various stacks and queues used to facilitate the above.
+  requests: null
+
+  # The various handlers to facilitate the above.
+  handlers:
+    'initialize':
+      abort: (method) ->
+        # Initialize request store.
+        @requests[method] or= null
+
+      stack: (method) ->
+        # Initialize request store.
+        @requests[method] or= []
+
+    'sync:before':
+      abort: (method, options) ->
+        # Abort a held request if we have one.
+        @requests[method].abort() if @requests[method]
+        # Wrap the callbacks so they won't be executed if we get disposed
+        # without being aborted.
+        if options
+          for name in ['success', 'error', 'complete']
+            options[name] = makeDisposable this, options[name]
+
+      stack: (method, options) ->
+        # Wrap the callbacks so they won't be executed if we get disposed.
+        if options
+          for name in ['success', 'error', 'complete']
+            options[name] = makeDisposable this, options[name]
+
+    'sync:after':
+      abort: (method, request) ->
+        # Wrap the request object so that it could be diposed without being
+        # aborted.
+        request = new Disposable this, request
+        # Store and return the request object for later abort.
+        @requests[method] = request
+
+      stack: (method, request) ->
+        # Keep track of the requests but do nothing beyond that.
+        requests = @requests[method]
+        request = new Disposable this, request
+        requests.push request
+        request = request.always =>
+          requests = @requests[method]
+          requests[i..i] = [] if (i = _.indexOf(requests, request)) > -1
+
+    'dispose':
+      abort: (method) ->
+        # Abort all stored requests.
+        requests = @requests[method]
+        if _(requests).isArray()
+          request.abort() for request in requests
+        else if requests
+          requests.abort()
+        delete @requests[method]
+
+  # Disposal
+  # --------
+
+  disposed: false
+
+  dispose: ->
+    return if @disposed
+
+    # Finished
+    @disposed = true
+
+    # Trigger disposal for each method.
+    @trigger "dispose:#{method}" for method in @methods
+
+    # Remove all event handlers on this module.
+    @off()
+
+    # You’re frozen when your heart’s not open
+    Object.freeze? this

--- a/test/index.html
+++ b/test/index.html
@@ -62,7 +62,8 @@
           'view',
           'delayer',
           'utils',
-          'sync_machine'
+          'sync_machine',
+          'strategist'
         ];
         var loaded = [];
         for (var i = 0, l = specs.length; i < l; i++) {

--- a/test/spec/strategist_spec.coffee
+++ b/test/spec/strategist_spec.coffee
@@ -1,0 +1,105 @@
+define [
+  'underscore'
+  'backbone'
+  'chaplin/mediator'
+  'chaplin/lib/strategist'
+], (_, Backbone, mediator, Strategist) ->
+  'use strict'
+
+  describe 'Strategist', ->
+    strategist = null
+
+    beforeEach ->
+      strategist = new Strategist()
+
+    afterEach ->
+      strategist.dispose()
+
+    it 'should mixin a Backbone.Events', ->
+      for own name, value of Backbone.Events
+        expect(strategist[name]).to.be Backbone.Events[name]
+
+    describe 'Strategy', ->
+      it 'should accept a string', ->
+        strategist.strategy = 'abort'
+        strategist.initialize()
+
+        expect(strategist.strategy).to.be.an 'object'
+        expect(strategist.strategy.sync.read).to.be 'abort'
+        expect(strategist.strategy.dispose.patch).to.be 'abort'
+
+      it 'should accept only describing hooks', ->
+        strategist.strategy =
+          sync: 'stack'
+          dispose: 'abort'
+        strategist.initialize()
+
+        expect(strategist.strategy.sync).to.be.an 'object'
+        expect(strategist.strategy.dispose).to.be.an 'object'
+        expect(strategist.strategy.sync.read).to.be 'stack'
+        expect(strategist.strategy.sync.patch).to.be 'stack'
+        expect(strategist.strategy.dispose.read).to.be 'abort'
+        expect(strategist.strategy.dispose.patch).to.be 'abort'
+
+      it 'should accept only describing methods with null as default', ->
+        strategist.strategy =
+          read: 'stack'
+          patch: 'abort'
+        strategist.initialize()
+
+        expect(strategist.strategy.sync).to.be.an 'object'
+        expect(strategist.strategy.dispose).to.be.an 'object'
+        expect(strategist.strategy.sync.read).to.be 'stack'
+        expect(strategist.strategy.sync.patch).to.be 'abort'
+        expect(strategist.strategy.dispose.read).to.be 'stack'
+        expect(strategist.strategy.dispose.patch).to.be 'abort'
+        expect(strategist.strategy.dispose.delete).to.be 'null'
+
+      it 'should accept the full object with null as default', ->
+        strategist.strategy =
+          sync:
+            read: 'stack'
+
+          dispose:
+            patch: 'abort'
+
+        strategist.initialize()
+
+        expect(strategist.strategy.sync).to.be.an 'object'
+        expect(strategist.strategy.dispose).to.be.an 'object'
+        expect(strategist.strategy.sync.read).to.be 'stack'
+        expect(strategist.strategy.sync.patch).to.be 'null'
+        expect(strategist.strategy.dispose.read).to.be 'null'
+        expect(strategist.strategy.dispose.patch).to.be 'abort'
+
+    describe 'Inheritance', ->
+      it 'should be extendable', ->
+        expect(Strategist.extend).to.be.a 'function'
+
+        DerivedStrategist = Strategist.extend()
+        derivedStrategist = new DerivedStrategist()
+        expect(derivedStrategist).to.be.a Strategist
+
+        derivedStrategist.dispose()
+
+      it 'should merge the handlers object', ->
+        class DerivedStrategist extends Strategist
+          handlers:
+            'initialize':
+              'newWave': -> # ...
+
+        derived = new DerivedStrategist
+          strategy: 'abort'
+
+        expect(derived.handlers.initialize.newWave).to.be.a 'function'
+        expect(derived.handlers['sync:before']).to.be.an 'object'
+        expect(derived.handlers.dispose.abort).to.be.a 'function'
+
+    describe 'Disposal', ->
+      it 'should dispose itself correctly', ->
+        expect(strategist.dispose).to.be.a 'function'
+        strategist.dispose()
+
+        expect(strategist.disposed).to.be true
+        if Object.isFrozen
+          expect(Object.isFrozen(strategist)).to.be true


### PR DESCRIPTION
This closes #63.
This is madness (as heard in 300). This truly is a land of madness. Though the implementation works great. :cake: Oh. And I like cake.

This is mostly what we discussed at the bottom of #63. There are 3 primary strategies: **null**, **stack**, and **abort**. **null** does nothing at all (this can be used to no-op this out of your models and collections if you don't want it). **abort** only allows one request at any given time and will abort the current request if another is made. This strategy also aborts the request on dispose. **stack** will keep track of requests but do nothing about it during the lifetime of a model (allows multiple concurrent requests) and on disposal it still does nothing except for one very important detail... no event handlers are called, the request simply finishes and moves along. These can be mixed a bit (ie. you can stack requests during lifetime but abort all current on dispose or do the reverse as in only allow one request but let it finish without calling event handlers).

Some examples (for the sake of brevity assume we're in the context of a model):

```coffee
# Nothing is done to the requests.
strategy: null  # or 'null'

# All requests follow the stack strategy all the way through.
strategy: 'stack'

# All requests abort themselves immediately as described above.
strategy: 'abort'

# Requests will abort each other to only allow one
# during sync operations but on dispose the last made 
# request will be allowed to finish
strategy:
  sync: 'abort'
  dispose: null

# Follow specific strategies based on the sync operation.
strategy:
  read: 'abort'
  create: 'stack'
  update: 'stack'
  patch: 'stack'
  delete: 'abort'

# The default for both models and collections:
strategy:
  sync:
    read: 'abort'
    create: 'stack'
    update: 'stack'
    patch: 'stack'
    delete: 'abort'

  dispose:
    read: 'abort'
    create: 'null'
    update: 'null'
    patch: 'null'
    delete: 'null'
```

Now for a disclaimer. This works great in everything I've tried *so far*. Something of this scale needs at least a week of people poking it before I'd be comfortable with it in master. There are no unit tests at the moment. I'm working on it. I'm submitting the pull now as I'd like some help designing the unit tests for the asynchronous requests. Do we mock `$.ajax`? 

---

Oh ... and this `Strategist` object is dead simple to extend with further strategies (such as a request queue) like follows:

```coffee
class Strategist extends Chaplin.Strategist
  handlers:
    'sync:before':
      'queue': (method, options) ->
        # Do things

    'sync:after':
      'queue': (method, request) ->
        # Do more things

    'dispose':
      'queue': (method) ->
        # Get rid of things

class Model extends Chaplin.Model
  strategy: 'queue'
  initStrategist: ->
    @strategist = new Strategist {@strategy}
```