### PR TITLE
Corrected two typos in the docs

### DIFF
--- a/docs/chaplin.event_broker.md
+++ b/docs/chaplin.event_broker.md
@@ -16,7 +16,7 @@ Unsubcribe the `handler` to the `event` (if it exists) before subscribing it. It
 Unsubcribe the `handler` to the `event`. It is like `Chaplin.mediator.unsubscribe`.
 
 
-### subscribeAllEvents()
+### unsubscribeAllEvents()
 Unsubcribe all handlers for all events.
 
 ## Usage

--- a/docs/chaplin.view.md
+++ b/docs/chaplin.view.md
@@ -329,5 +329,5 @@ Unsubcribe the `handler` to the `event` (if it exists) before subscribing it. It
 ### unsubscribeEvent(event, handler)
 Unsubcribe the `handler` to the `event`. It is like `Chaplin.mediator.unsubscribe`.
 
-### subscribeAllEvents()
+### unsubscribeAllEvents()
 Unsubcribe all handlers for all events.


### PR DESCRIPTION
Both chaplin.event_broker.md and chaplin.view.md have documentation for subscribeAllEvents() and this should be unsubscribeAllEvents()
