### PR TITLE
Don't route requests immediately after loading routes

### DIFF
--- a/src/chaplin/application.coffee
+++ b/src/chaplin/application.coffee
@@ -66,9 +66,6 @@ module.exports = class Application
     # Register any provided routes.
     routes? @router.match
 
-    # After registering the routes, start **Backbone.history**.
-    @router.startHistory()
-
   #### Disposal
   disposed: false
 

--- a/test/spec/application_spec.coffee
+++ b/test/spec/application_spec.coffee
@@ -55,8 +55,8 @@ define [
       expect(routesCalled).to.be true
       expect(passedMatch).to.be.a 'function'
 
-    it 'should start Backbone.history', ->
-      expect(Backbone.History.started).to.be true
+    it 'should not start Backbone.history', ->
+      expect(Backbone.History.started).to.be false
 
     it 'should dispose itself correctly', ->
       expect(app.dispose).to.be.a 'function'


### PR DESCRIPTION
We ran into trouble trying to use the "url" view helper in Brunch for named routes in our layout. This helper depends on the router (obviously), but the layout is being initialized in `@initLayout()`, which comes before `@initRouter` in the initialization sequence.

I think the best solution is to load routes at the beginning of application init, making them available to the rest of the init process. Then we call `startHistory()` at the end to actually route requests.

This will require an adjustment to the Chaplin init sequence. With this patch, our `application.coffee` file in Brunch now looks like this:

``` coffeescript
  initialize: ->
    super

    # Register all routes
    @initRouter routes

    # Initialize core components
    @initDispatcher controllerSuffix: '-controller'
    @initLayout()
    @initMediator()

    # Application-specific scaffold
    @initControllers()

    # Actually start routing
    @router.startHistory()

    # Freeze the application instance to prevent further changes
    Object.freeze? this
```
