### PR TITLE
Update outdated SyncMachine docs

### DIFF
--- a/docs/chaplin.sync_machine.md
+++ b/docs/chaplin.sync_machine.md
@@ -117,7 +117,7 @@ define [
       super
 
       # Initialize the SyncMachine
-      _(@).extend Chaplin.SyncMachine
+      _(this).extend Chaplin.SyncMachine
 
       # Will be called on every state change
       @syncStateChange announce


### PR DESCRIPTION
`initSyncMachine` was removed in 72863848337f47ca3216ff6f443d8ba7bf571fcf, updating the docs to reflect that.
