### PR TITLE
Updated dispatcher documentation

### DIFF
--- a/docs/chaplin.dispatcher.md
+++ b/docs/chaplin.dispatcher.md
@@ -18,8 +18,8 @@ The `Dispatcher` sits between the router and the controllers. It listens for a r
     * **controllerSuffix**: the suffix used for controller files. *Default: '_controller'*
 
 ## Usage
-A specific controller can be started programatically by publishing an app-wide `!startupController` event which will be handled by the `Dispatcher`:
+A specific controller can be started programatically by publishing an app-wide `startupController` event which will be handled by the `Dispatcher`:
 
 ```coffeescript
-Chaplin.mediator.publish '!startupController', 'controller', 'action', params
+Chaplin.mediator.publish 'startupController', 'controller', 'action', params
 ```


### PR DESCRIPTION
Renamed the `startupController` event name.  

Just wanted to confirm that a leader `!` is used as a convention for global events, correct?
