### PR TITLE
Fix the route reversal helper to allow for empty paths/'home'-links

### DIFF
--- a/src/chaplin/lib/helpers.coffee
+++ b/src/chaplin/lib/helpers.coffee
@@ -8,10 +8,10 @@ helpers =
 
   # Returns the url for a named route and any params.
   reverse: (routeName, params...) ->
-    url = false
+    url = null
     # Don't worry, this callback happens synchronously.
     mediator.publish '!router:reverse', routeName, params, (result) ->
-      if result
+      if result isnt false
         url = "/#{result}"
       else
         throw new Error 'Chaplin.helpers.reverse: invalid route specified.'

--- a/test/spec/helpers_spec.coffee
+++ b/test/spec/helpers_spec.coffee
@@ -21,14 +21,26 @@ define [
         url = helpers.reverse 'foo', id: 3, d: "data"
         expect(url).to.be '/foo/bar'
 
-      it 'should return false if no route found', ->
+      it 'should return the url for a named route with empty path', ->
+        stubbedRouteHandler = (routeName, params, cb) ->
+          expect(routeName).to.be 'home'
+          expect(params).to.eql []
+          cb ''
+        mediator.subscribe '!router:reverse', stubbedRouteHandler
+
+        url = helpers.reverse 'home'
+        expect(url).to.be '/'
+
+      it 'should throw exception if no route found', ->
         stubbedRouteHandler = (routeName, params, cb) ->
           cb false
         mediator.subscribe '!router:reverse', stubbedRouteHandler
 
-        url = helpers.reverse 'foo', id: 3, d: "data"
-        expect(url).to.be false
+        try
+          url = helpers.reverse 'foo', id: 3, d: "data"
+        catch err
+          expect(err).to.be.an.instanceof Error
 
-      it 'should return false if router doesn\'t respond', ->
+      it 'should return null if router doesn\'t respond', ->
         url = helpers.reverse 'foo', id: 3, d: "data"
-        expect(url).to.be false
+        expect(url).to.be null


### PR DESCRIPTION
The route reversal helper doesnt account for

```
  match '', 'home#index', name: 'home'
```

This PR fixes that.

Note that there was already a failing test in the helper spec. I tried to clean it up but couldnt get it working, could someone take a look at it? Its the one checking for failed look ups that throws an exception.
