### PR TITLE
content: protocol in links

### DIFF
--- a/src/chaplin/views/layout.coffee
+++ b/src/chaplin/views/layout.coffee
@@ -45,7 +45,6 @@ module.exports = class Layout # This class does not extend View.
       skipRouting: '.noscript'
       # Per default, jump to the top of the page.
       scrollTo: [0, 0]
-      isExternalLink: @defaultIsExternalLink
 
     @regions = []
 
@@ -109,7 +108,7 @@ module.exports = class Layout # This class does not extend View.
     if @settings.routeLinks
       $(document).off 'click', @settings.routeLinks
 
-  defaultIsExternalLink: (link) ->
+  isExternalLink: (link) ->
     link.target is '_blank' or
     link.rel is 'external' or
     link.protocol not in ['http:', 'https:', 'file:'] or
@@ -141,7 +140,7 @@ module.exports = class Layout # This class does not extend View.
       type is 'string' and $el.is skipRouting
 
     # Handle external links.
-    external = isAnchor and @settings.isExternalLink el
+    external = isAnchor and @isExternalLink el
     if external
       if @settings.openExternalToBlank
         # Open external links normally in a new tab.

--- a/test/spec/layout_spec.coffee
+++ b/test/spec/layout_spec.coffee
@@ -155,8 +155,7 @@ define [
 
     it 'custom isExternalLink receives link properties', ->
       stub = sinon.stub().returns true
-      layout.dispose()
-      layout = new Layout title: '', isExternalLink: stub
+      layout.isExternalLink = stub
       expectWasNotRouted href: 'http://www.example.org:1234/foo?bar=1#baz', target: "_blank", rel: "external"
 
       expect(stub).was.calledOnce()
@@ -168,13 +167,11 @@ define [
       expect(link.host).to.be "www.example.org:1234"
 
     it 'custom isExternalLink should not route if true', ->
-      layout.dispose()
-      layout = new Layout title: '', isExternalLink: -> true
+      layout.isExternalLink = -> true
       expectWasNotRouted href: '/foo'
 
     it 'custom isExternalLink should route if false', ->
-      layout.dispose()
-      layout = new Layout title: '', isExternalLink: -> false
+      layout.isExternalLink = -> false
       expectWasRouted href: '/foo', rel: "external"
 
     # With custom routing options


### PR DESCRIPTION
I'm running into trouble with Chaplin's built-in link click handler in a Trigger.io app. Trigger uses the `content:` protocol for their pages, which doesn't get along well with this code:

``` coffeescript
# layout.coffee
return if isAnchor and (
  # ...
  el.protocol not in ['http:', 'https:', 'file:']
)
```

Can we either add `content:` to the allowed list, or make it configurable, maybe with a setting passed to `Chaplin.Layout`?
