### PR TITLE
mediator.once/Backbone.Events.once with EventBroker support

### DIFF
--- a/src/chaplin/lib/event_broker.coffee
+++ b/src/chaplin/lib/event_broker.coffee
@@ -29,6 +29,20 @@ EventBroker =
     # Register global handler, force context to the subscriber.
     mediator.subscribe type, handler, this
 
+  subscribeOnce: (type, handler) ->
+    if typeof type isnt 'string'
+      throw new TypeError 'EventBroker#subscribeOnce: ' +
+        'type argument must be a string'
+    if typeof handler isnt 'function'
+      throw new TypeError 'EventBroker#subscribeOnce: ' +
+        'handler argument must be a function'
+
+    # Ensure that a handler isn’t registered twice.
+    mediator.unsubscribe type, handler, this
+
+    # Register global handler, force context to the subscriber.
+    mediator.once type, handler, this
+
   unsubscribeEvent: (type, handler) ->
     if typeof type isnt 'string'
       throw new TypeError 'EventBroker#unsubscribeEvent: ' +

--- a/src/chaplin/mediator.coffee
+++ b/src/chaplin/mediator.coffee
@@ -29,12 +29,13 @@ mediator = {}
 mediator.subscribe   = Backbone.Events.on
 mediator.unsubscribe = Backbone.Events.off
 mediator.publish     = Backbone.Events.trigger
+mediator.once        = Backbone.Events.once
 
 # Initialize an empty callback list so we might seal the mediator later.
 mediator._callbacks = null
 
 # Make properties readonly.
-utils.readonly mediator, 'subscribe', 'unsubscribe', 'publish'
+utils.readonly mediator, 'subscribe', 'unsubscribe', 'publish', 'once'
 
 # Sealing the mediator
 # --------------------

--- a/test/spec/event_broker_spec.coffee
+++ b/test/spec/event_broker_spec.coffee
@@ -25,6 +25,21 @@ define [
 
       mediator.unsubscribe type, spy
 
+    it 'should subscribe once to events', ->
+      expect(eventBroker.subscribeOnce).to.be.a 'function'
+
+      # We could mock mediator.publish here and test if it was called,
+      # well, better testing the outcome.
+      type = 'eventBrokerTest'
+      spy = sinon.spy()
+      eventBroker.subscribeOnce type, spy
+
+      mediator.publish type, 1, 2, 3, 4
+      mediator.publish type, 5, 6, 7, 8
+      expect(spy).was.calledOnce()
+      expect(spy).was.calledWith 1, 2, 3, 4
+      expect(spy).was.calledOn eventBroker
+
     it 'should not subscribe the same handler twice', ->
       type = 'eventBrokerTest'
       spy = sinon.spy()
@@ -38,11 +53,25 @@ define [
 
       mediator.unsubscribe type, spy
 
+      spy = sinon.spy()
+      eventBroker.subscribeOnce type, spy
+      eventBroker.subscribeOnce type, spy
+
+      mediator.publish type, 1, 2, 3, 4
+      expect(spy).was.calledOnce()
+      expect(spy).was.calledWith 1, 2, 3, 4
+      expect(spy).was.calledOn eventBroker
+
     it 'should check the params when subscribing', ->
       expect(-> eventBroker.subscribeEvent()).to.throwError()
       expect(-> eventBroker.subscribeEvent(undefined, undefined)).to.throwError()
       expect(-> eventBroker.subscribeEvent(1234, ->)).to.throwError()
       expect(-> eventBroker.subscribeEvent('event', {})).to.throwError()
+
+      expect(-> eventBroker.subscribeOnce()).to.throwError()
+      expect(-> eventBroker.subscribeOnce(undefined, undefined)).to.throwError()
+      expect(-> eventBroker.subscribeOnce(1234, ->)).to.throwError()
+      expect(-> eventBroker.subscribeOnce('event', {})).to.throwError()
 
     it 'should unsubscribe from events', ->
       expect(eventBroker.unsubscribeEvent).to.be.a 'function'
@@ -50,6 +79,13 @@ define [
       type = 'eventBrokerTest'
       spy = sinon.spy()
       eventBroker.subscribeEvent type, spy
+      eventBroker.unsubscribeEvent type, spy
+
+      mediator.publish type
+      expect(spy).was.notCalled()
+
+      spy = sinon.spy()
+      eventBroker.subscribeOnce type, spy
       eventBroker.unsubscribeEvent type, spy
 
       mediator.publish type

--- a/test/spec/mediator_spec.coffee
+++ b/test/spec/mediator_spec.coffee
@@ -14,11 +14,12 @@ define [
       expect(mediator.subscribe).to.be.a 'function'
       expect(mediator.unsubscribe).to.be.a 'function'
       expect(mediator.publish).to.be.a 'function'
+      expect(mediator.once).to.be.a 'function'
 
     it 'should have readonly Pub/Sub methods', ->
       return unless support.propertyDescriptors and
         Object.getOwnPropertyDescriptor
-      methods = ['subscribe', 'unsubscribe', 'publish']
+      methods = ['subscribe', 'unsubscribe', 'publish', 'once']
       _(methods).forEach (property) ->
         desc = Object.getOwnPropertyDescriptor(mediator, property)
         expect(desc.enumerable).to.be true


### PR DESCRIPTION
Caveat:

The current way the EventBroker works is to unsubscribe existing handlers with the same name.

So if you have one handler listening for events and then add a once handler for the same event, the handler will be unsubscribed and replaced with a once subscriber, and the other way around.

I think this is correct :)
