### PR TITLE
Do not create `subviews` until they are used.

### DIFF
--- a/src/chaplin/views/collection_view.coffee
+++ b/src/chaplin/views/collection_view.coffee
@@ -424,7 +424,7 @@ module.exports = class CollectionView extends View
     visibilityChanged = false
 
     visibleItemsIndex = _(@visibleItems).indexOf item
-    includedInVisibleItems = visibleItemsIndex > -1
+    includedInVisibleItems = visibleItemsIndex isnt -1
 
     if includedInFilter and not includedInVisibleItems
       # Add item to the visible items list.

--- a/src/chaplin/views/view.coffee
+++ b/src/chaplin/views/view.coffee
@@ -277,7 +277,7 @@ module.exports = class View extends Backbone.View
 
     # Remove the subview from the lists.
     index = _.indexOf subviews, view
-    subviews.splice index, 1 if index > -1
+    subviews.splice index, 1 if index isnt -1
     delete byName[name]
 
   # Rendering


### PR DESCRIPTION
A lot of empty `subviews` arrays clutters debugger. And considering we now have regions, subviews are not needed 100% of the time. This shall delay initialising them until they are actually used. Also, slight perf gain.

Also, do not throw error if `initialize` was not redefined, not needed now.
