### PR TITLE
Check for event target in View when disposing collections. Closes gh-518...

### DIFF
--- a/src/chaplin/views/view.coffee
+++ b/src/chaplin/views/view.coffee
@@ -101,7 +101,9 @@ module.exports = class View extends Backbone.View
     # Listen for disposal of the model or collection.
     # If the model is disposed, automatically dispose the associated view.
     @listenTo @model, 'dispose', @dispose if @model
-    @listenTo @collection, 'dispose', @dispose if @collection
+    if @collection
+      @listenTo @collection, 'dispose', (subject) =>
+        @dispose() if not subject or subject is @collection
 
     # Register all exposed regions.
     @publishEvent '!region:register', this if @regions?

--- a/test/spec/view_spec.coffee
+++ b/test/spec/view_spec.coffee
@@ -631,12 +631,26 @@ define [
         for prop in properties
           expect(view).not.to.have.own.property prop
 
-      it 'should dispose itself when the model or collection is disposed', ->
+      it 'should dispose itself when the model is disposed', ->
         model = new Model()
-        view = new TestView model: model
+        view = new TestView {model}
         model.dispose()
         expect(model.disposed).to.be true
         expect(view.disposed).to.be true
+
+      it 'should dispose itself when the collection is disposed', ->
+        collection = new Collection()
+        view = new TestView {collection}
+        collection.dispose()
+        expect(collection.disposed).to.be true
+        expect(view.disposed).to.be true
+
+      it 'should not dispose itself when the collection model is disposed', ->
+        collection = new Collection [{a: 1}, {a: 2}, {a: 3}]
+        view = new TestView {collection}
+        collection.at(0).dispose()
+        expect(collection.disposed).to.be false
+        expect(view.disposed).to.be false
 
       it 'should not render when disposed given render wasn’t overridden', ->
         # Vanilla View which doesn’t override render


### PR DESCRIPTION
@mehcode review please, this is pretty critical bug.

Will release 0.8.1 today.
