### PR TITLE
Fix SyncMachine example

### DIFF
--- a/docs/chaplin.sync_machine.md
+++ b/docs/chaplin.sync_machine.md
@@ -162,7 +162,7 @@ class Model extends Chaplin.Model
     options.success = (model, response) =>
       success? model, response
       @finishSync()
-    super
+    super options
 
 # Will render view when model data will arrive from server.
 class View extends Chaplin.View


### PR DESCRIPTION
If we don't give `options` to super call, it will never call the original `success` callback and `finishSync` function
