### PR TITLE
Remove underscorising of controller names.

### DIFF
--- a/src/chaplin/dispatcher.coffee
+++ b/src/chaplin/dispatcher.coffee
@@ -75,7 +75,7 @@ module.exports = class Dispatcher
   # The default implementation uses require() from a AMD module loader
   # like RequireJS to fetch the constructor.
   loadController: (name, handler) ->
-    fileName = utils.underscorize(name) + @settings.controllerSuffix
+    fileName = name + @settings.controllerSuffix
     moduleName = @settings.controllerPath + fileName
     if define?.amd
       require [moduleName], handler

--- a/src/chaplin/lib/utils.coffee
+++ b/src/chaplin/lib/utils.coffee
@@ -71,11 +71,6 @@ utils =
   upcase: (str) ->
     str.charAt(0).toUpperCase() + str.substring(1)
 
-  # underScoreHelper -> under_score_helper.
-  underscorize: (string) ->
-    string.replace /[A-Z]/g, (char, index) ->
-      (if index isnt 0 then '_' else '') + char.toLowerCase()
-
   # Escapes a string to use in a regex.
   escapeRegExp: (str) ->
     return String(str or '').replace /([.*+?^=!:${}()|[\]\/\\])/g, '\\$1'

--- a/test/spec/utils_spec.coffee
+++ b/test/spec/utils_spec.coffee
@@ -61,8 +61,3 @@ define [
         expect(utils.upcase 'stuff').to.be 'Stuff'
         expect(utils.upcase 'стафф').to.be 'Стафф'
         expect(utils.upcase '123456').to.be '123456'
-
-    describe 'underscorize', ->
-      it 'should convert camelCase to underscore_case', ->
-        expect(utils.underscorize 'userNameAndAge').to.be 'user_name_and_age'
-        expect(utils.underscorize 'User').to.be 'user'


### PR DESCRIPTION
As discussed in https://github.com/chaplinjs/chaplin-boilerplate/issues/7

This removes `helloWorld#show` == `hello_world#show` meaning. User will need to directly name controllers in camelCase or use underscores / dashes in string.

This is also for consistency with default route names which don’t convert things to camelCase automatically.
