### PR TITLE
Add Collection#set() support to CollectionView

### DIFF
--- a/src/chaplin/views/collection_view.coffee
+++ b/src/chaplin/views/collection_view.coffee
@@ -158,8 +158,8 @@ module.exports = class CollectionView extends View
   # -----------------
 
   # When an item is added, create a new view and insert it.
-  itemAdded: (item, collection, options = {}) =>
-    @insertView item, @renderItem(item), options.index
+  itemAdded: (item, collection, options) =>
+    @insertView item, @renderItem(item), options.at
 
   # When an item is removed, remove the corresponding view from DOM and caches.
   itemRemoved: (item) =>
@@ -338,14 +338,12 @@ module.exports = class CollectionView extends View
         'must be defined or the initItemView() must be overridden.'
 
   # Inserts a view into the list at the proper position.
-  insertView: (item, view, index = null, enableAnimation = true) ->
+  insertView: (item, view, position, enableAnimation = true) ->
     enableAnimation = false if @animationDuration is 0
 
-    # Get the insertion offset.
-    position = if typeof index is 'number'
-      index
-    else
-      @collection.indexOf item
+    # Get the insertion offset if not given.
+    unless typeof position is 'number'
+      position = @collection.indexOf item
 
     # Is the item included in the filter?
     included = if typeof @filterer is 'function'


### PR DESCRIPTION
Small code change and spec additions are necessary.

Revamp the complete CollectionView spec, structure it with `describe`, reorder the parts. Make `collection`/`collectionView` setup explicit so there are no `dispose()` calls right at the beginning of examples.

[This is the spec part that was added.](https://github.com/chaplinjs/chaplin/blob/1109bc4e4dfb3e51dac693776266a2a60dac450e/test/spec/collection_view_spec.coffee#L352-L414) It’s hard to spot due to the overall cleanup.

Side note: What was wrong with `options.index`? This is a just relict of our old `Collection#update` method. Backbone does not add the `index` option to `add` events. Okay, but why did that cause a problem? It should be `undefined`! The current `Collection#set` implementation may call `Collection#remove` which adds `index` to the passed options without making a copy of it. Long story short, there might be an `index` option present even when it’s an `add` event. … WTF. Took me a while to figure that out. I’m glad we added all those `options = _.clone(options)` calls some time ago.
