### PR TITLE
Remove rejected and initDeferred according to #540

### DIFF
--- a/docs/chaplin.collection.md
+++ b/docs/chaplin.collection.md
@@ -5,14 +5,11 @@
 ## Methods of `Chaplin.Collection`
 All `Backbone.Collection` [methods](http://backbonejs.org/#Collection).
 
-### initDeferred()
-Creates a new [jQuery Deferred object](http://api.jquery.com/category/deferred-object/) instance.
-
 ### serialize()
 Memory-saving serializing of models. Maps models to their attributes recursively. Creates an object which delegates to the original attributes when a property needs to be overwritten.
 
 ### dispose()
-Announces to all associated views that the model is being disposed. Unbinds all the global event handlers and also removes all the event handlers on the Model module. If the collection is a Deferred, it will be rejected. Removes internal attribute hashes and event handlers. Attempts to [freeze](https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Object/freeze) the Collection to prevent any changes to the Collection.
+Announces to all associated views that the model is being disposed. Unbinds all the global event handlers and also removes all the event handlers on the Model module. Removes internal attribute hashes and event handlers. Attempts to [freeze](https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Object/freeze) the Collection to prevent any changes to the Collection.
 
 ## Usage
 Please do not register their methods directly as Pub/Sub listeners, use `subscribeEvent` instead. This forces the handler context so the handler might be removed again on model/collection disposal. It’s crucial to remove all references to model/collection methods to allow them to be garbage collected.

--- a/docs/chaplin.model.md
+++ b/docs/chaplin.model.md
@@ -5,9 +5,6 @@
 ## Methods of `Chaplin.Model`
 All `Backbone.Model` [methods](http://backbonejs.org/#Model).
 
-### initDeferred()
-Creates a new [jQuery Deferred object](http://api.jquery.com/category/deferred-object/) instance.
-
 ### getAttributes()
 Gets the attributes from the view template and can be overwritten by decorators which cannot create a proper 'attributes' getter due to the absence of getters and setters in ECMAScript 3.
 
@@ -15,7 +12,7 @@ Gets the attributes from the view template and can be overwritten by decorators 
 Memory-saving serializing of model attributes. Maps models to their attributes recursively. Creates an object which delegates to the original attributes when a property needs to be overwritten.
 
 ### dispose()
-Announces to all associated collections and views that the model is being disposed. Unbinds all the global event handlers and also removes all the event handlers on the Model module. If the model is a Deferred, it will be rejected.  Removes the collection reference, internal attribute hashes and event handlers.  Attempts to freeze the Model to prevent any changes to the Model. See [Object.freeze](https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Object/freeze).
+Announces to all associated collections and views that the model is being disposed. Unbinds all the global event handlers and also removes all the event handlers on the Model module. Removes the collection reference, internal attribute hashes and event handlers.  Attempts to freeze the Model to prevent any changes to the Model. See [Object.freeze](https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Object/freeze).
 
 ## Usage
 Please do not register their methods directly as Pub/Sub listeners, use `subscribeEvent` instead. This forces the handler context so the handler might be removed again on model/collection disposal. It’s crucial to remove all references to model/collection methods to allow them to be garbage collected.

--- a/docs/handling_async.md
+++ b/docs/handling_async.md
@@ -10,7 +10,7 @@ Model-view-binding, Backbone’s key feature, is still a building block in Chapl
 
 Models, collections and third-party scripts typically have a loaded state. But they're often not ready for use initially because they rely upon asynchronous input such as waiting for data to be fetched from the server or a successful user login.
 
-For this purpose, [jQuery Deferreds](http://api.jquery.com/category/deferred-object/) (or [standalone-deferreds](https://github.com/Mumakil/Standalone-Deferred) if you're using Zepto) can be mixed into application objects. They allow registering of load handlers using the [done](http://api.jquery.com/deferred.done/) method. The handlers will be called once the Deferred is resolved.
+For this purpose, [jQuery Deferreds](http://api.jquery.com/category/deferred-object/) (or [standalone-deferreds](https://github.com/Mumakil/Standalone-Deferred) if you're using Zepto) could be utilized. They allow registering of load handlers using the [done](http://api.jquery.com/deferred.done/) method. The handlers will be called once the Deferred is resolved.
 
 Deferreds are a versatile pattern which can be used on different levels in an application, but they're rather simple because they only have three states (pending, resolved, rejected) and two transitions (resolve, reject). For more complex synchronization tasks, Chaplin offers the `SyncMachine` which is a state machine.
 

--- a/src/chaplin/models/collection.coffee
+++ b/src/chaplin/models/collection.coffee
@@ -15,10 +15,6 @@ module.exports = class Collection extends Backbone.Collection
   # Use the Chaplin model per default, not Backbone.Model.
   model: Model
 
-  # Mixin a Deferred.
-  initDeferred: ->
-    _(this).extend $.Deferred()
-
   # Serializes collection.
   serialize: ->
     @map utils.serialize
@@ -46,10 +42,6 @@ module.exports = class Collection extends Backbone.Collection
 
     # Remove all event handlers on this module.
     @off()
-
-    # If the model is a Deferred, reject it
-    # This does nothing if it was resolved before.
-    @reject?()
 
     # Remove model constructor reference, internal model lists
     # and event handlers.

--- a/src/chaplin/models/model.coffee
+++ b/src/chaplin/models/model.coffee
@@ -59,10 +59,6 @@ module.exports = class Model extends Backbone.Model
   # Mixin an EventBroker.
   _(@prototype).extend EventBroker
 
-  # Mixin a Deferred.
-  initDeferred: ->
-    _(this).extend $.Deferred()
-
   # This method is used to get the attributes for the view template
   # and might be overwritten by decorators which cannot create a
   # proper `attributes` getter due to ECMAScript 3 limits.
@@ -95,10 +91,6 @@ module.exports = class Model extends Backbone.Model
 
     # Remove all event handlers on this module.
     @off()
-
-    # If the model is a Deferred, reject it
-    # This does nothing if it was resolved before.
-    @reject?()
 
     # Remove the collection reference, internal attribute hashes
     # and event handlers.

--- a/src/chaplin/views/collection_view.coffee
+++ b/src/chaplin/views/collection_view.coffee
@@ -127,10 +127,6 @@ module.exports = class CollectionView extends View
   getTemplateData: ->
     templateData = {length: @collection.length}
 
-    # If the collection is a Deferred, add a `resolved` flag.
-    if typeof @collection.state is 'function'
-      templateData.resolved = @collection.state() is 'resolved'
-
     # If the collection is a SyncMachine, add a `synced` flag.
     if typeof @collection.isSynced is 'function'
       templateData.synced = @collection.isSynced()

--- a/src/chaplin/views/view.coffee
+++ b/src/chaplin/views/view.coffee
@@ -296,11 +296,6 @@ module.exports = class View extends Backbone.View
 
     source = @model or @collection
     if source
-      # If the model/collection is a Deferred, add a `resolved` flag,
-      # but only if it’s not present yet.
-      if typeof source.state is 'function' and not ('resolved' of data)
-        data.resolved = source.state() is 'resolved'
-
       # If the model/collection is a SyncMachine, add a `synced` flag,
       # but only if it’s not present yet.
       if typeof source.isSynced is 'function' and not ('synced' of data)

--- a/test/spec/collection_spec.coffee
+++ b/test/spec/collection_spec.coffee
@@ -25,13 +25,6 @@ define [
       for own name, value of EventBroker
         expect(collection[name]).to.be EventBroker[name]
 
-    it 'should initialize a Deferred', ->
-      expect(collection.initDeferred).to.be.a 'function'
-      collection.initDeferred()
-      for method in ['done', 'fail', 'progress', 'state', 'promise']
-        expect(typeof collection[method]).to.be 'function'
-      expect(collection.state()).to.be 'pending'
-
     it 'should serialize the models', ->
       model1 = new Model id: 1, foo: 'foo'
       model2 = new Backbone.Model id: 2, bar: 'bar'
@@ -100,16 +93,6 @@ define [
 
         model.trigger 'foo'
         expect(spy).was.notCalled()
-
-      it 'should reject the Deferred on disposal', ->
-        collection.initDeferred()
-        failSpy = sinon.spy()
-        collection.fail failSpy
-
-        collection.dispose()
-
-        expect(collection.state()).to.be 'rejected'
-        expect(failSpy).was.called()
 
       it 'should remove instance properties', ->
         collection.dispose()

--- a/test/spec/model_spec.coffee
+++ b/test/spec/model_spec.coffee
@@ -20,13 +20,6 @@ define [
       for own name, value of EventBroker
         expect(model[name]).to.be EventBroker[name]
 
-    it 'should initialize a Deferred', ->
-      expect(model.initDeferred).to.be.a 'function'
-      model.initDeferred()
-      for method in ['done', 'fail', 'progress', 'state', 'promise']
-        expect(typeof model[method]).to.be 'function'
-      expect(model.state()).to.be 'pending'
-
     it 'should return the attributes per default', ->
       expect(model.getAttributes()).to.be model.attributes
 
@@ -189,16 +182,6 @@ define [
 
         model2.trigger 'foo'
         expect(spy).was.notCalled()
-
-      it 'should reject the Deferred on disposal', ->
-        model.initDeferred()
-        failSpy = sinon.spy()
-        model.fail failSpy
-
-        model.dispose()
-
-        expect(model.state()).to.be 'rejected'
-        expect(failSpy).was.called()
 
       it 'should remove instance properties', ->
         model.dispose()

--- a/test/spec/view_spec.coffee
+++ b/test/spec/view_spec.coffee
@@ -362,15 +362,6 @@ define [
       expect(items[1]).to.be.an 'object'
       expect(items[1].bar).to.be 'bar'
 
-    it 'should add the Deferred state to the template data', ->
-      setModel()
-      model.initDeferred()
-      templateData = view.getTemplateData()
-      expect(templateData.resolved).to.be false
-      model.resolve()
-      templateData = view.getTemplateData()
-      expect(templateData.resolved).to.be true
-
     it 'should add the SyncMachine state to the template data', ->
       setModel()
       _.extend model, SyncMachine


### PR DESCRIPTION
Couldnt run tests. phantomjs times out n shit :/ 

I keept this link ( https://github.com/chaplinjs/facebook-example/blob/master/coffee/lib/utils.coffee ) in the docs to because even if most of the stuff could be solved with beforeAction today it contains a lot of goodies.  Perhaps Chaplin should offer something like the deferMethods util instead of initDeferred?
