### PR TITLE
Allow in View#undelegate to unbind 1 handler. Closes gh-531.

### DIFF
--- a/src/chaplin/views/view.coffee
+++ b/src/chaplin/views/view.coffee
@@ -184,8 +184,28 @@ module.exports = class View extends Backbone.View
     return
 
   # Remove all handlers registered with @delegate.
-  undelegate: ->
-    @$el.unbind ".delegate#{@cid}"
+  undelegate: (eventName, second, third) ->
+    if eventName
+      if typeof eventName isnt 'string'
+        throw new TypeError 'View#undelegate: first argument must be a string'
+
+      if arguments.length is 2
+        if typeof second is 'string'
+          selector = second
+        else
+          handler = second
+      else if arguments.length is 3
+        selector = second
+        if typeof selector isnt 'string'
+          throw new TypeError 'View#undelegate: ' +
+            'second argument must be a string'
+        handler = third
+
+      list = _.map eventName.split(' '), (event) => "#{event}.delegate#{@cid}"
+      events = list.join(' ')
+      @$el.off events, (selector or null)
+    else
+      @$el.off ".delegate#{@cid}"
 
   # Handle declarative event bindings from `listen`
   delegateListeners: ->

--- a/test/spec/view_spec.coffee
+++ b/test/spec/view_spec.coffee
@@ -162,11 +162,11 @@ define [
       spy = sinon.spy()
       handler = view.delegate 'click', spy
       expect(handler).to.be.a 'function'
-      $(view.el).trigger 'click'
+      view.$el.trigger 'click'
       expect(spy).was.called()
 
       view.undelegate()
-      $(view.el).trigger 'click'
+      view.$el.trigger 'click'
       expect(spy.callCount).to.be 1
 
       view.render()
@@ -187,14 +187,31 @@ define [
     it 'should register and remove multiple user input event handlers', ->
       spy = sinon.spy()
       handler = view.delegate 'click keypress', spy
-      $(view.el).trigger 'click'
-      $(view.el).trigger 'keypress'
+      view.$el.trigger 'click'
+      view.$el.trigger 'keypress'
       expect(spy).was.calledTwice()
 
       view.undelegate()
-      $(view.el).trigger 'click'
-      $(view.el).trigger 'keypress'
+      view.$el.trigger 'click'
+      view.$el.trigger 'keypress'
       expect(spy).was.calledTwice()
+
+    it 'should allow undelegating one event', ->
+      spy = sinon.spy()
+      spy2 = sinon.spy()
+      handler = view.delegate 'click keypress', spy
+      handler2 = view.delegate 'focusout', spy2
+      view.$el.trigger 'click'
+      view.$el.trigger 'keypress'
+      expect(spy).was.calledTwice()
+      expect(spy2).was.notCalled()
+
+      view.undelegate 'click keypress'
+      view.$el.trigger 'click'
+      view.$el.trigger 'keypress'
+      view.$el.trigger 'focusout'
+      expect(spy).was.calledTwice()
+      expect(spy2).was.calledOnce()
 
     it 'should check delegate parameters', ->
       expect(-> view.delegate 1, 2, 3).to.throwError()


### PR DESCRIPTION
there are A LOT of duplicated code in `View#{_delegateEvents,delegateEvents,delegate,undelegate,delegateListeners}` btw
