### PR TITLE
Add Rails-style lambda constraints

### DIFF
--- a/src/chaplin/lib/route.coffee
+++ b/src/chaplin/lib/route.coffee
@@ -116,9 +116,12 @@ module.exports = class Route
     # Apply the parameter constraints.
     constraints = @options.constraints
     if constraints
-      params = @extractParams path
-      for own name, constraint of constraints
-        return false unless constraint.test(params[name])
+      if _.isFunction constraints
+        return false unless constraints()
+      else
+        params = @extractParams path
+        for own name, constraint of constraints
+          return false unless constraint.test(params[name])
 
     return true
 


### PR DESCRIPTION
This would allow a Rails-style lambda constraint so you could say something like:

``` coffeescript
match '', 'users#dashboard', constraints: -> isLoggedIn()
match '', 'pages#startPage'
```

It needs tests before being pulled, but I wanted to see if there was interest in such a thing. I know you can basically accomplish the same thing in the controller, but I just like this method better.
