### PR TITLE
add example for self region to docs

### DIFF
--- a/docs/chaplin.view.md
+++ b/docs/chaplin.view.md
@@ -303,6 +303,7 @@ class MyView extends Chaplin.View
   regions:
     '#page .container > .sidebar': 'sidebar'
     '#page .container > .content': 'body'
+    '': 'myview'
 ```
 
 When the view is initialzied the regions hashes of all base classes are
@@ -325,6 +326,7 @@ class MyView extends Chaplin.View
     super
     @registerRegion '#page .container > .sidebar', 'sidebar'
     @registerRegion '#page .container > .content', 'body'
+    @registerRegion '', 'myview'
 ```
 
 ### unregisterRegion(name)


### PR DESCRIPTION
As shown in #585 it wasn't clear to me that you can use an empty selector string to bind a canonical region name to the view's element, although I studied the docs and have been using Chaplin since version 0.6 extensively. Please consider adding this to the docs.
