### PR TITLE
Add release automation via Grunt. Closes gh-599.

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -86,6 +86,32 @@ module.exports = (grunt) ->
           forceOverwriteSources: true
           relativeType: 'bundle'
 
+    # Publishing via Git
+    # ------------------
+    transbrute:
+      docs:
+        remote: 'git@github.com:chaplinjs/chaplin.git'
+        branch: 'gh-pages'
+        files: [
+          { expand: true, cwd: 'docs/', src: '**/*' }
+        ]
+      downloads:
+        message: "Release #{pkg.version}."
+        remote: 'git@github.com:chaplinjs/downloads.git'
+        branch: 'gh-pages'
+        files: [
+          { expand: true, cwd: 'build/', src: '{amd,brunch}/chaplin.{js,min.js}' },
+          {
+            dest: 'component.json',
+            body: {
+              name: 'chaplin',
+              version: pkg.version,
+              main: 'amd/chaplin.js',
+              dependencies: { backbone: '>= 1.0.0' }
+            }
+          }
+        ]
+
     # Module naming
     # -------------
     # TODO: Remove this when uRequire hits 0.3
@@ -424,32 +450,110 @@ module.exports = (grunt) ->
     'watch'
   ]
 
+  # Releasing
+  # ---------
+
+  grunt.registerTask 'check:versions:component', 'Check that package.json and component.json versions match', ->
+    componentVersion = grunt.file.readJSON('component.json').version
+    unless componentVersion is pkg.version
+      grunt.fail.warn "component.json is version #{componentVersion}, package.json is #{pkg.version}."
+    else
+      grunt.log.ok()
+
+  grunt.registerTask 'check:versions:changelog', 'Check that CHANGELOG.md is up to date', ->
+    # Require CHANGELOG.md to contain "Chaplin VERSION (DIGIT"
+    changelogMd = grunt.file.read('CHANGELOG.md')
+    unless RegExp("Chaplin #{pkg.version} \\(\\d").test changelogMd
+      grunt.fail.warn "CHANGELOG.md does not seem to be updated for #{pkg.version}."
+    else
+      grunt.log.ok()
+
+  grunt.registerTask 'check:versions:docs', 'Check that package.json and docs versions match', ->
+    template = grunt.file.read path.join('docs', '_layouts', 'default.html')
+    match = template.match /^version: ((\d+)\.(\d+)\.(\d+)(?:-[\dA-Za-z\-]*)?)$/m
+    unless match
+      grunt.fail.warn "Version missing in docs layout."
+    docsVersion = match[1]
+    unless docsVersion is pkg.version
+      grunt.fail.warn "Docs layout is version #{docsVersion}, package.json is #{pkg.version}."
+    else
+      grunt.log.ok()
+
+  grunt.registerTask 'check:versions', [
+    'check:versions:component',
+    'check:versions:changelog',
+    'check:versions:docs'
+  ]
+
+  grunt.registerTask 'release:git', 'Check context, commit and tag for release.', ->
+    prompt = require 'prompt'
+    prompt.start()
+    prompt.message = prompt.delimiter = ''
+    prompt.colors = false
+    # Command/query wrapper, turns description object for `spawn` into runner
+    command = (desc, message) ->
+      (next) ->
+        grunt.log.writeln message if message
+        grunt.util.spawn desc, (err, result, code) -> next(err)
+    query = (desc) ->
+      (next) -> grunt.util.spawn desc, (err, result, code) -> next(err, result)
+    # Help checking input from prompt. Returns a callback that calls the
+    # original callback `next` only if the input was as expected
+    checkInput = (expectation, next) ->
+      (err, input) ->
+        unless input and input.question is expectation
+          grunt.fail.warn "Aborted: Expected #{expectation}, got #{input}"
+        next()
+
+    steps = []
+    continuation = this.async()
+
+    # Check for master branch
+    steps.push query(cmd: 'git', args: ['rev-parse', '--abbrev-ref', 'HEAD'])
+    steps.push (result, next) ->
+      if result is 'master'
+        next()
+      else
+        prompt.get([
+            description: "Current branch is #{result}, not master. 'ok' to continue, Ctrl-C to quit."
+            pattern: /^ok$/, required: true
+          ],
+          checkInput('ok', next)
+        )
+    # List dirty files, ask for confirmation
+    steps.push query(cmd: 'git', args: ['status', '--porcelain'])
+    steps.push (result, next) ->
+      grunt.fail.warn "Nothing to commit." unless result.toString().length
+
+      grunt.log.writeln "The following dirty files will be committed:"
+      grunt.log.writeln result
+      prompt.get([
+          description: "Commit these files? 'ok' to continue, Ctrl-C to quit.",
+          pattern: /^ok$/, required: true
+        ],
+        checkInput('ok', next)
+      )
+
+    # Commit
+    steps.push command(cmd: 'git', args: ['commit', '-a', '-m', "Release #{pkg.version}"])
+
+    # Tag
+    steps.push command(cmd: 'git', args: ['tag', '-a', pkg.version])
+
+    grunt.util.async.waterfall steps, continuation
+
+  grunt.registerTask 'release', [
+    'check:versions',
+    'release:git',
+    'build',
+    'build:minified',
+    'transbrute:docs',
+    'transbrute:downloads'
+  ]
+
   # Publish Documentation
   # ---------------------
-  grunt.registerTask 'docs:publish', 'Publish docs to gh-pages branch.', ->
-    path = require('path')
-    temp = require('temp')
-
-    continuation = this.async()
-    tmpDirPath = temp.path()
-
-    grunt.file.recurse path.join('docs'), (abspath, rootdir, subdir, filename) ->
-      parent = if subdir then path.join(tmpDirPath, subdir) else tmpDirPath
-      grunt.file.mkdir parent
-      grunt.file.copy abspath, path.join(parent, filename)
-    gitArgs = [
-      ['init', '.']
-      ['add', '.'],
-      ['commit', '-m', "Add docs from #{(new Date).toISOString()}"],
-      ['remote', 'add', 'origin', 'git@github.com:chaplinjs/chaplin.git'],
-      ['push', 'origin', 'master:refs/heads/gh-pages', '--force']
-    ]
-    gitRunner = (args, next) ->
-      grunt.util.spawn {cmd: "git", args: args, opts: {cwd: tmpDirPath}}, (error, result, code) -> next(error)
-    grunt.util.async.forEachSeries gitArgs, gitRunner, ->
-      grunt.file.delete tmpDirPath, force: true
-      grunt.log.writeln "Published docs to gh-pages."
-      continuation()
+  grunt.registerTask 'docs:publish', ['check:versions:docs', 'transbrute:docs']
 
   # Default
   # -------

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "grunt-urequire": "git://github.com/concordusapps/grunt-urequire",
     "grunt-coffeelint": "0.0.x",
     "grunt-mocha": "0.2.x",
-    "temp": "0.5.x",
+    "grunt-transbrute": "0.1.x",
+    "prompt": "0.2.x",
     "phantomjs": "1.8.x"
   },
   "main": "build/commonjs/chaplin.js",


### PR DESCRIPTION
This adds a task for releasing new versions of Chaplin by running `grunt release`.

The following actions are performed:
1. Check that version numbers appearing in `component.json`, the docs and `CHANGELOG.md` match the one given in `package.json`. If they don't, the task fails. (Ended up not going for automatic bumping of version numbers, since I wasn't sure whether the use of it is high enough to justify the necessary work to get it right. We could still add it, though, if you prefer)
2. Perform some checks relating to the repository, commit and tag
   - Checks if current branch is `master` and prompts user about this if it is not
   - Lists the dirty files, i.e. those that would be committed and asks the user to confirm
   - `git commit -am "Release #{pkg.version}"`
   - `git tag -a #{pkg.version}`
3. Build and minify
4. Publish current docs from source
5. Publish downloads to [chaplinjs/downloads](https://github.com/chaplinjs/downloads)

Both 4., and 5. happen via [knuton/grunt-transbrute](https://github.com/knuton/grunt-transbrute), which I extracted from the task I wrote for this initially.

The only thing that I didn't do is add auto-generation of the tweet text, since with the current setup the script doesn't have access to the prior version number.
