### PR TITLE
Update docs for changed regions API

### DIFF
--- a/docs/chaplin.view.md
+++ b/docs/chaplin.view.md
@@ -301,11 +301,11 @@ var MyView = Chaplin.View.extend({});
 this.view = new MyView({region: 'sidebar'});
 ```
 
-However the latter case leaves it to the controller to decide (through whatever logic) where to place the view.
+However the latter case is more flexible, as it leaves it to the controller to decide (through whatever logic) where to place the view.
 
 <h3 class="module-member" id="regions">regions</h3>
 
-A region registration hash that works much like the declarative events hash present in Backbone.
+A region registration hash that works much like the declarative events hash present in Backbone. Region names are specifyed as keys, region selectors as values. If the region selector is empty (`''`), the view’s own DOM element will be selected.
 
 The following snippet will register the named regions `sidebar` and `body` and bind them to their respective selectors directly on the prototype:
 
@@ -313,17 +313,17 @@ The following snippet will register the named regions `sidebar` and `body` and b
 # myview.coffee
 class MyView extends Chaplin.View
   regions:
-    '#page .container > .sidebar': 'sidebar'
-    '#page .container > .content': 'body'
-    '': 'myview'
+    'sidebar': '#page .container > .sidebar'
+    'body': '#page .container > .content'
+    'myview': '' 
 ```
 ```javascript
 // myview.js
 var MyView = Chaplin.View({
   regions: {
-    '#page .container > .sidebar': 'sidebar',
-    '#page .container > .content': 'body',
-    '': 'myview'
+    'sidebar': '#page .container > .sidebar',
+    'body': '#page .container > .content',
+    'myview': '' 
   }
 });
 ```
@@ -338,9 +338,9 @@ class MyView extends Chaplin.View
 # [...] inside action method
 @view = new MyView
   regions:
-    '#page .container > .sidebar': 'sidebar'
-    '#page .container > .content': 'body'
-    '': 'myview'
+    'sidebar': '#page .container > .sidebar'
+    'body': '#page .container > .content'
+    'myview': '' 
 ```
 ```javascript
 // myview.js
@@ -350,9 +350,9 @@ var MyView = Chaplin.View({});
 // [...] inside action method
 this.view = new MyView({
   regions: {
-    '#page .container > .sidebar': 'sidebar',
-    '#page .container > .content': 'body',
-    '': 'myview'
+    'sidebar': '#page .container > .sidebar',
+    'body': '#page .container > .content',
+    'myview': '' 
   }
 });
 ```


### PR DESCRIPTION
Update docs for #620.

I know that this would cause even more breakage, but I think the signature of [`registerRegion`](http://docs.chaplinjs.org/chaplin.view.html#registerRegion) should be updated, too. This will otherwise be a constant source of confusion. Better to break once cleanly and properly. @paulmillr, I think [your script](https://gist.github.com/paulmillr/5891455) could be updated to handle this change in a similar fashion?

Should be done before #614.
