### PR TITLE
Correct collection_view docs typo

### DIFF
--- a/docs/chaplin.collection_view.md
+++ b/docs/chaplin.collection_view.md
@@ -96,7 +96,7 @@ The `CollectionView` is responsible for displaying collections. For every item i
 
 ```coffeescript
 filterer: (item, index) ->
-  item.get 'color' is 'red'
+  item.get('color') is 'red'
 
 ...
 


### PR DESCRIPTION
As written, the filterer example compiles to item.get('color' === red), not item.get('color') === red.
