### PR TITLE
Add Application#start, remove Application#startRouting.

### DIFF
--- a/src/chaplin/application.coffee
+++ b/src/chaplin/application.coffee
@@ -28,15 +28,15 @@ module.exports = class Application
   layout: null
   router: null
   composer: null
-  initialized: false
+  started: false
 
   constructor: (options = {}) ->
     @initialize options
 
   initialize: (options = {}) ->
-    # Check if app is already initialized.
-    if @initialized
-      throw new Error 'Application#initialize: App was already initialized'
+    # Check if app is already started.
+    if @started
+      throw new Error 'Application#initialize: App was already started'
 
     # Initialize core components.
     # ---------------------------
@@ -61,14 +61,8 @@ module.exports = class Application
     # Mediator is a global message broker which implements pub / sub pattern.
     @initMediator()
 
-    # Actually start routing.
-    @startRouting()
-
-    # Mark app as initialized.
-    @initialized = true
-
-    # Freeze the application instance to prevent further changes.
-    Object.freeze? this
+    # Start the application.
+    @start()
 
   # **Chaplin.Dispatcher** sits between the router and controllers to listen
   # for routing events. When they occur, Chaplin.Dispatcher loads the target
@@ -115,9 +109,16 @@ module.exports = class Application
     # Register any provided routes.
     routes? @router.match
 
-  startRouting: ->
+  # Can be customized when overridden.
+  start: ->
     # After registering the routes, start **Backbone.history**.
     @router.startHistory()
+
+    # Mark app as initialized.
+    @started = true
+
+    # Freeze the application instance to prevent further changes.
+    Object.freeze? this
 
   # Disposal
   # --------

--- a/test/spec/application_spec.coffee
+++ b/test/spec/application_spec.coffee
@@ -68,9 +68,9 @@ define [
       expect(passedMatch).to.be.a 'function'
       expect(Backbone.History.started).to.be false
 
-    it 'should start Backbone.history with startRouting()', ->
+    it 'should start Backbone.history with start()', ->
       app.initRouter (->), root: '/', pushState: false
-      app.startRouting()
+      app.start()
       expect(Backbone.History.started).to.be true
       Backbone.history.stop()
 


### PR DESCRIPTION
Also, rename Application.initialized to .started for consistency.

`start` method is very useful in many apps.

You may want to pre-load some data before application is started. Or do something, when all components were initialised but were not started.

It can be done as follows:

``` coffeescript
start: ->
  @mediator.user.fetch().then =>
    super
```
