### PR TITLE
Improve support for `file:` schema.

### DIFF
--- a/src/chaplin/lib/router.coffee
+++ b/src/chaplin/lib/router.coffee
@@ -17,8 +17,11 @@ module.exports = class Router # This class does not extend Backbone.Router.
   _.extend @prototype, EventBroker
 
   constructor: (@options = {}) ->
+    # Enable pushState by default for HTTP(s).
+    # Disable it for file:// schema.
+    isWebFile = window.location.protocol isnt 'file:'
     _.defaults @options,
-      pushState: true
+      pushState: isWebFile
       root: '/'
 
     # Cached regex for stripping a leading subdir and hash/slash.

--- a/src/chaplin/views/layout.coffee
+++ b/src/chaplin/views/layout.coffee
@@ -118,7 +118,7 @@ module.exports = class Layout extends View
       if @settings.openExternalToBlank
         # Open external links normally in a new tab.
         event.preventDefault()
-        window.open el.href
+        window.open href
       return
 
     if isAnchor


### PR DESCRIPTION
Very useful for Cordova / Phonegap:

Auto-detect `file:`s in router and disable push state by default for it.

No way to test this afaik. I did manual tests and it works.
