### PR TITLE
Add Router#namespace to match pattern with prefix

### DIFF
--- a/src/chaplin/lib/router.coffee
+++ b/src/chaplin/lib/router.coffee
@@ -75,6 +75,10 @@ module.exports = class Router # This class does not extend Backbone.Router.
     Backbone.history.handlers.push {route, callback: route.handler}
     route
 
+  # Run `match` with given namespace as a prefix of pattern.
+  namespace: (prefix, callback) =>
+    callback (pattern, args...) => @match prefix + pattern, args...
+
   # Route a given URL path manually. Returns whether a route matched.
   # This looks quite like Backbone.History::loadUrl but it
   # accepts an absolute URL with a leading slash (e.g. /foo)

--- a/test/spec/router_spec.coffee
+++ b/test/spec/router_spec.coffee
@@ -201,6 +201,15 @@ define [
 
         mediator.unsubscribe 'router:match', spy
 
+      it 'should match with namespace', ->
+        spy = sinon.spy()
+        mediator.subscribe 'router:match', spy
+        router.namespace 'foo/', (match) =>
+          match 'bar', 'null#null'
+
+        router.route 'foo/bar'
+        expect(spy).was.called()
+
     describe 'Passing the Route', ->
 
       it 'should pass the route to the router:match handler', ->


### PR DESCRIPTION
Hi,

I'm happily using chaplin.js in production(not yet released). Thanks for great product!

I added Router#namespace to DRY up the nested route definition. Our app has many long nested routes, so this method wil be very useful to clean up our `routes.coffee`.

example: 

``` coffeescript
match 'users/:user_id', 'users#show'

namespace 'users/:user_id/', (match) ->
  match 'friends', 'users#friends' 
```
