### PR TITLE
Improve default Layout title template.

### DIFF
--- a/src/chaplin/views/layout.coffee
+++ b/src/chaplin/views/layout.coffee
@@ -36,7 +36,9 @@ module.exports = class Layout extends View
     @title = options.title
     @regions = options.regions if options.regions
     @settings = _.defaults options,
-      titleTemplate: _.template("<%= subtitle %> \u2013 <%= title %>")
+      titleTemplate: _.template(
+        "<% if (subtitle) { %><%= subtitle %> \u2013 <% } %><%= title %>"
+      )
       openExternalToBlank: false
       routeLinks: 'a, .go-to'
       skipRouting: '.noscript'


### PR DESCRIPTION
If subtitle is empty, do not show a separator.
