### PR TITLE
Added `fallbackSelector` and `loadingSelector` to constructor instance options

### DIFF
--- a/src/chaplin/views/collection_view.coffee
+++ b/src/chaplin/views/collection_view.coffee
@@ -96,7 +96,8 @@ module.exports = class CollectionView extends View
   constructor: (options) ->
     # Apply options to view instance.
     if (options)
-      _.extend this, _.pick options, ['renderItems', 'itemView']
+      _.extend this, _.pick options,
+        ['renderItems', 'itemView', 'fallbackSelector', 'loadingSelector']
 
     # Initialize list for visible items.
     @visibleItems = []


### PR DESCRIPTION
- both `fallbackSelector` and `loadingSelector` are useful when not subclassing CollectionView.
- dont need a template on the CollectionView to work.

ex:

``` coffeescript
    @subview 'items', new CollectionView
      region: 'items'
      noWrap: yes
      itemView: MyItemView
      collection: @items
      fallbackSelector: '.no-items'
```
