### PR TITLE
Bug fix for IE8-9: don't rely on the strict mode

### DIFF
--- a/src/chaplin/controllers/controller.coffee
+++ b/src/chaplin/controllers/controller.coffee
@@ -39,9 +39,8 @@ module.exports = class Controller
   # Convenience method to publish the `!composer:compose` event. See the
   # composer for information on parameters, etc.
   compose: (name) ->
-    retrieve = (arguments.length is 1)
-    name = if retrieve then 'retrieve' else 'compose'
-    mediator.execute "composer:#{name}", arguments...
+    method = if arguments.length is 1 then 'retrieve' else 'compose'
+    mediator.execute "composer:#{method}", arguments...
 
   # Redirection
   # -----------


### PR DESCRIPTION
As IE<=9 don't support the strict mode, we can't rely on its features like immutable `arguments`.
