### PR TITLE
Do not re-attach a view on re-render

### DIFF
--- a/src/chaplin/views/view.coffee
+++ b/src/chaplin/views/view.coffee
@@ -407,8 +407,7 @@ module.exports = class View extends Backbone.View
     mediator.execute 'region:show', @region, this if @region?
 
     # Automatically append to DOM if the container element is set.
-    if @container
-      # Append the view to the DOM.
+    if @container and not document.body.contains @el
       $(@container)[@containerMethod] @el
       # Trigger an event.
       @trigger 'addedToDOM'

--- a/test/spec/view_spec.coffee
+++ b/test/spec/view_spec.coffee
@@ -117,6 +117,13 @@ define [
       expect(view.el).to.be testbed.previousSibling
       expect(view.el.parentNode).to.be testbed.parentNode
 
+    it 'should not attach itself more than once', ->
+      spy = sinon.spy $::, 'append'
+      view = new TestView container: testbed
+      view.render()
+      view.render()
+      expect(spy.calledOnce).to.be true
+
     it 'should not attach itself if autoAttach is false', ->
       class NoAutoAttachView1 extends View
         autoAttach: false


### PR DESCRIPTION
A solution for chaplinjs/chaplin/issues/670

Calling `view.render()` on a View that has already been rendered causes
it to be re-attached.

Add an `isAttached` flag to View so we know if we need to re-render
or not.
