### PR TITLE
Bigfixes and improvements for query params processing

### DIFF
--- a/src/chaplin/dispatcher.coffee
+++ b/src/chaplin/dispatcher.coffee
@@ -22,6 +22,7 @@ module.exports = class Dispatcher
   currentController: null
   currentRoute: null
   currentParams: null
+  currentQuery: null
 
   constructor: ->
     @initialize arguments...
@@ -52,6 +53,9 @@ module.exports = class Dispatcher
     params = if params then _.clone(params) else {}
     options = if options then _.clone(options) else {}
 
+    # null or undefined query parameters are equivalent to an empty hash
+    options.query = {} if not options.query?
+
     # Whether to update the URL after controller startup.
     # Default to true unless explicitly set to false.
     options.changeURL = true unless options.changeURL is false
@@ -66,7 +70,8 @@ module.exports = class Dispatcher
     return if not options.forceStartup and
       @currentRoute?.controller is route.controller and
       @currentRoute?.action is route.action and
-      _.isEqual @currentParams, params
+      _.isEqual(@currentParams, params) and
+      _.isEqual @currentQuery, options.query
 
     # Fetch the new controller, then go on.
     @loadController route.controller, (Controller) =>
@@ -103,6 +108,7 @@ module.exports = class Dispatcher
     # Save the new controller and its parameters.
     @currentController = controller
     @currentParams = params
+    @currentQuery = options.query
 
     # Call the controller action with params and options.
     controller[route.action] params, route, options

--- a/src/chaplin/lib/route.coffee
+++ b/src/chaplin/lib/route.coffee
@@ -81,7 +81,8 @@ module.exports = class Route
 
     # Stringify query params if needed.
     if typeof query is 'object'
-      url += '?' + utils.queryParams.stringify query
+      queryString = utils.queryParams.stringify query
+      url += if queryString then '?' + queryString else ''
     else
       url += (if query[0] is '?' then '' else '?') + query
 

--- a/src/chaplin/lib/utils.coffee
+++ b/src/chaplin/lib/utils.coffee
@@ -92,13 +92,15 @@ utils =
     # Returns a query string from a hash
     stringify: (queryParams) ->
       query = ''
+      stringifyKeyValuePair = (encodedKey, value) ->
+        if value? then '&' + encodedKey + '=' + encodeURIComponent value else ''
       for own key, value of queryParams
         encodedKey = encodeURIComponent key
         if _.isArray value
           for arrParam in value
-            query += '&' + encodedKey + '=' + encodeURIComponent arrParam
+            query += stringifyKeyValuePair encodedKey, arrParam
         else
-          query += '&' + encodedKey + '=' + encodeURIComponent value
+          query += stringifyKeyValuePair encodedKey, value
       query and query.substring 1
 
     # Returns a hash with query parameters from a query string

--- a/test/spec/utils_spec.coffee
+++ b/test/spec/utils_spec.coffee
@@ -63,11 +63,15 @@ define [
         expect(utils.upcase '123456').to.be '123456'
 
     describe 'queryParams', ->
-      queryParams = 'p1': 'With space', 'p 2': [999, 'a&b']
-      queryString = 'p1=With%20space&p%202=999&p%202=a%26b'
+      queryParams = p1: 'With space', p2_empty: '', 'p 3': [999, 'a&b']
+      queryString = 'p1=With%20space&p2_empty=&p%203=999&p%203=a%26b'
 
       it 'should serialize query parameters from object into string', ->
         expect(utils.queryParams.stringify queryParams).to.be queryString
+
+      it 'should ignore undefined and null values when serializing query parameters', ->
+        queryParams1 = p1: null, p2: undefined, p3: 'third'
+        expect(utils.queryParams.stringify queryParams1).to.be 'p3=third'
 
       it 'should deserialize query parameters from query string into object', ->
         expect(utils.queryParams.parse queryString).to.eql queryParams


### PR DESCRIPTION
This includes a critical bugfix (the first one in a list below) for #682 and some more improvements:
- `Dispatcher::dispatch` now checks if `options.query` hash was changed. I forgot this check initially, so if you navigate between routes differ only in query parameters, nothing will happen :-(
- `Route::reverse` now won't add a ? symbol at the end of a returned url if you pass an empty object as a `query` parameter (second one)
- `utils.queryParams.stringify` will now ignore `undefined` and `null` values

IMO, we should release 0.11.1 ASAP
