### PR TITLE
Avoid reattaching through re-render

### DIFF
--- a/src/chaplin/views/view.coffee
+++ b/src/chaplin/views/view.coffee
@@ -102,6 +102,8 @@ module.exports = class View extends Backbone.View
       render.apply this, arguments
       # Attach to DOM.
       @attach arguments... if @autoAttach
+      # Make sure the element is not reattached to the DOM when re-rendering.
+      @autoAttach = false
       # Return the view.
       this
 


### PR DESCRIPTION
If `view.autoAttach is true` the `view.el` is reattached to the `view.region` or `view.container` whenever `veiw.render()` is called.

I don't see why a view needs to be attached multiple times to `view.region` or `view.container`.
