### PR TITLE
Add tags to downloads update task. Closes GH-691.

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -98,6 +98,8 @@ module.exports = (grunt) ->
         ]
       downloads:
         message: "Release #{pkg.version}."
+        tag: pkg.version
+        tagMessage: "Version #{pkg.version}."
         remote: 'git@github.com:chaplinjs/downloads.git'
         branch: 'gh-pages'
         files: [

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "grunt-urequire": "git://github.com/concordusapps/grunt-urequire",
     "grunt-coffeelint": "0.0.x",
     "grunt-mocha": "0.2.x",
-    "grunt-transbrute": "~0.1.1",
+    "grunt-transbrute": "~0.2.0",
     "prompt": "0.2.x",
     "phantomjs": "1.8.x"
   },


### PR DESCRIPTION
See #691. Need to run `npm install` to update grunt-transbrute.
