### PR TITLE
Fixed hashchange support detection in browser

### DIFF
--- a/src/chaplin/lib/history.coffee
+++ b/src/chaplin/lib/history.coffee
@@ -60,7 +60,7 @@ module.exports = class History extends Backbone.History
     # 'onhashchange' is supported, determine how we check the URL state.
     if (@_hasPushState)
       Backbone.$(window).on 'popstate', @checkUrl
-    else if @_wantsHashChange and 'onhashchange' in window and not oldIE
+    else if @_wantsHashChange and 'onhashchange' of window and not oldIE
       Backbone.$(window).on 'hashchange', @checkUrl
     else if @_wantsHashChange
       @_checkUrlInterval = setInterval @checkUrl, @interval


### PR DESCRIPTION
During the rewriting process of the Backbone.History a bug was introduced.
The operator "in" in Coffeescript is not the same as the one used in Javascript.
This pull-request replaces the "in" operator with "of", to properly detect the "hashchange" support.
