### PR TITLE
TYPO: This functions like -> This function is like

### DIFF
--- a/docs/chaplin.event_broker.md
+++ b/docs/chaplin.event_broker.md
@@ -13,7 +13,7 @@ The `EventBroker` offers an interface to interact with [Chaplin.mediator](./chap
 Publishes `event` globablly, passing `arguments` along for interested subscribers.
 
 <h3 class="module-member" id="subscribeEvent">subscribeEvent(event, handler)</h3>
-Subscribes the `handler` to the given `event`. If `handler` already subscribed to `event`, it will be removed as a subscriber and added afresh. This functions like `Chaplin.mediator.subscribe` except it cannot subscribe twice.
+Subscribes the `handler` to the given `event`. If `handler` already subscribed to `event`, it will be removed as a subscriber and added afresh. This function is like `Chaplin.mediator.subscribe` except it cannot subscribe twice.
 
 <h3 class="module-member" id="unsubscribeEvent">unsubscribeEvent(event, handler)</h3>
 Unsubcribe the `handler` from the `event`. This functions like `Chaplin.mediator.unsubscribe`.


### PR DESCRIPTION
The functions don't like, but there is a function that _is_ like `Chaplin.mediator.subscribe`
