### PR TITLE
Fixes #708 which breaks loading element on Zepto

### DIFF
--- a/src/chaplin/views/collection_view.coffee
+++ b/src/chaplin/views/collection_view.coffee
@@ -15,7 +15,7 @@ filterChildren = (nodeList, selector) ->
 
 toggleElement = do ->
   if $
-    (elem, visible) -> elem.toggle visible
+    (elem, visible) -> elem.css 'display', (if visible then 'block' else 'none')
   else
     (elem, visible) ->
       elem.style.display = (if visible then '' else 'none')


### PR DESCRIPTION
As discussed in #708 in Zepto the toggle method fails to work when the element is not yet inserted into the DOM. This avoids this by just setting the CSS property directly, which doesn't require the DOM or CSS parsing to occur.
