### PR TITLE
Allow listSelector to be used as a function

### DIFF
--- a/src/chaplin/views/collection_view.coffee
+++ b/src/chaplin/views/collection_view.coffee
@@ -237,10 +237,12 @@ module.exports = class CollectionView extends View
     super
 
     # Set the $list property with the actual list container.
+    listSelector = _.result this, 'listSelector'
+
     if $
-      @$list = if @listSelector then @$(@listSelector) else @$el
+      @$list = if listSelector then @$(listSelector) else @$el
     else
-      @list = if @listSelector then @find(@listSelector) else @el
+      @list = if listSelector then @find(@listSelector) else @el
 
     @initFallback()
     @initLoadingIndicator()


### PR DESCRIPTION
For consistency with `el`, `id`, `className`, `attributes`, etc. 
