### PR TITLE
Dont set filterer to non-function

### DIFF
--- a/src/chaplin/views/collection_view.coffee
+++ b/src/chaplin/views/collection_view.coffee
@@ -346,8 +346,12 @@ module.exports = class CollectionView extends View
   # show/hide the view or mark it otherwise as filtered.
   filter: (filterer, filterCallback) ->
     # Save the filterer and filterCallback functions.
-    @filterer = filterer
-    @filterCallback = filterCallback if filterCallback
+    if typeof filterer is 'function' or filterer is null
+      @filterer = filterer
+    if typeof filterCallback is 'function' or filterCallback is null
+      @filterCallback = filterCallback
+
+    filterer ?= @filterer
     filterCallback ?= @filterCallback
 
     hasItemViews = do =>
@@ -374,7 +378,7 @@ module.exports = class CollectionView extends View
             "no view found for #{item.cid}"
 
         # Show/hide or mark the view accordingly.
-        @filterCallback view, included
+        filterCallback view, included
 
         # Update visibleItems list, but do not trigger an event immediately.
         @updateVisibleItems view.model, included, false

--- a/test/spec/collection_view_spec.coffee
+++ b/test/spec/collection_view_spec.coffee
@@ -528,6 +528,12 @@ define [
         collectionView.filter filterer
         expect(filterer.callCount).to.be collection.length
 
+      it 'should not set filterer to non-function', ->
+        basicSetup()
+        filterer = collectionView.filterer = sinon.spy -> true
+        collectionView.filter()
+        expect(filterer.callCount).to.be collection.length
+
       it 'should hide filtered views per default', ->
         basicSetup()
         addThree()


### PR DESCRIPTION
I ran into this recently:

``` coffeescript
class FilterBox extends View
  events:
    'change input': 'filter'
```

If the first argument (in this case, a jQuery event) is not a function, Chaplin incorrectly sets the `@filterer` to be that argument (even in the case where the argument is `undefined`). Particularly for non-coffeescript files, this looks really ugly. Calling `@filter()` should just work.
