### PR TITLE
Fix matching routes with trailing slash (refs #532)

### DIFF
--- a/src/chaplin/dispatcher.coffee
+++ b/src/chaplin/dispatcher.coffee
@@ -6,6 +6,9 @@ mediator = require 'chaplin/mediator'
 utils = require 'chaplin/lib/utils'
 EventBroker = require 'chaplin/lib/event_broker'
 
+# Cached regex for removing a trailing slash.
+trailingSlash = /(\/$|\/(\?))/
+
 module.exports = class Dispatcher
   # Borrow the static extend method from Backbone.
   @extend = Backbone.Model.extend
@@ -32,6 +35,7 @@ module.exports = class Dispatcher
     @settings = _.defaults options,
       controllerPath: 'controllers/'
       controllerSuffix: '_controller'
+      trailing: no
 
     # Listen to global events.
     @subscribeEvent 'router:match', @dispatch
@@ -64,6 +68,13 @@ module.exports = class Dispatcher
     # if current and new controllers and params match
     # Default to false unless explicitly set to true.
     options.forceStartup = false unless options.forceStartup is true
+
+    if trailingSlash.test route.path
+      if @settings.trailing is no
+        route.path = route.path.replace trailingSlash, '$2'
+    else
+      if @settings.trailing is yes
+        route.path += '/'
 
     # Stop if the desired controller/action is already active
     # with the same params.

--- a/src/chaplin/lib/route.coffee
+++ b/src/chaplin/lib/route.coffee
@@ -77,6 +77,13 @@ module.exports = class Route
       value = params[name]
       url = url.replace ///[:*]#{name}///g, value
 
+    # Add or remove trailing slash according to options
+    switch @options.trailing
+      when yes
+        url += '/' unless url[-1..] is '/'
+      when no
+        url = url[...-1] if url[-1..] is '/'
+
     return url unless query
 
     # Stringify query params if needed.
@@ -135,9 +142,9 @@ module.exports = class Route
       # Replace named parameters, collecting their names.
       .replace(/(?::|\*)(\w+)/g, @addParamName)
 
-    # Create the actual regular expression, match until the end of the URL or
-    # the begin of query string.
-    @regExp = ///^#{pattern}(?=\?|$)///
+    # Create the actual regular expression, match until the end of the URL,
+    # trailing slash or the begin of query string.
+    @regExp = ///^#{pattern}(?=\?|\/?$|\/\?)///
 
   addParamName: (match, paramName) =>
     # Save parameter name.

--- a/test/spec/dispatcher_spec.coffee
+++ b/test/spec/dispatcher_spec.coffee
@@ -98,6 +98,56 @@ define [
 
     # The Tests
 
+    it 'should add the trailing slash to route path', (done) ->
+      controllerLoaded = sinon.spy dispatcher, 'controllerLoaded'
+      dispatcher.settings.trailing = yes
+
+      publishMatch route1, params, options
+
+      loadTest1Controller ->
+        [passedRoute] = controllerLoaded.firstCall.args
+
+        expect(controllerLoaded).was.calledOnce()
+        expect(passedRoute.path).to.match /\/$/
+
+        controllerLoaded.restore()
+
+        done()
+
+    it 'should remove the trailing slash from route path', (done) ->
+      controllerLoaded = sinon.spy dispatcher, 'controllerLoaded'
+      dispatcher.settings.trailing = no
+
+      route1.path += '/'
+      publishMatch route1, params, options
+
+      loadTest1Controller ->
+        [passedRoute] = controllerLoaded.firstCall.args
+
+        expect(controllerLoaded).was.calledOnce()
+        expect(passedRoute.path).not.to.match /\/$/
+
+        controllerLoaded.restore()
+
+        done()
+
+    it 'should leave the trailing slash in the route path', (done) ->
+      controllerLoaded = sinon.spy dispatcher, 'controllerLoaded'
+      dispatcher.settings.trailing = null
+
+      route1.path += '/'
+      publishMatch route1, params, options
+
+      loadTest1Controller ->
+        [passedRoute] = controllerLoaded.firstCall.args
+
+        expect(controllerLoaded).was.calledOnce()
+        expect(passedRoute.path).to.match /\/$/
+
+        controllerLoaded.restore()
+
+        done()
+
     it 'should dispatch routes to controller actions', (done) ->
       proto = Test1Controller.prototype
       initialize = sinon.spy proto, 'initialize'


### PR DESCRIPTION
Hi,

It's an attempt to fix non-functioning routes when using trailing slash. I stumbled upon it while testing my app with urls like http://app-domain.dev/recipes vs http://app-domain.dev/recipes/, where in the latter case Chaplin doesn't recognise my routes anymore.

My `routes.js.coffee`:

``` coffeescript
define ->
  'use strict'

  (match) ->

    # ... snip ...

    match 'recipes',          'recipes#index', name: 'recipes'
    match 'recipes/new',      'recipes#new',   name: 'new_recipe'
    match 'recipes/:id',      'recipes#show',  name: 'recipe'
    match 'recipes/:id/edit', 'recipes#edit',  name: 'edit_recipe'

    # ... snip ...
```
