### PR TITLE
Move trailing option into Router. Use its value as default for routes.

### DIFF
--- a/src/chaplin/dispatcher.coffee
+++ b/src/chaplin/dispatcher.coffee
@@ -6,9 +6,6 @@ mediator = require 'chaplin/mediator'
 utils = require 'chaplin/lib/utils'
 EventBroker = require 'chaplin/lib/event_broker'
 
-# Cached regex for removing a trailing slash.
-trailingSlash = /(\/$|\/(\?))/
-
 module.exports = class Dispatcher
   # Borrow the static extend method from Backbone.
   @extend = Backbone.Model.extend
@@ -35,7 +32,6 @@ module.exports = class Dispatcher
     @settings = _.defaults options,
       controllerPath: 'controllers/'
       controllerSuffix: '_controller'
-      trailing: no
 
     # Listen to global events.
     @subscribeEvent 'router:match', @dispatch
@@ -68,13 +64,6 @@ module.exports = class Dispatcher
     # if current and new controllers and params match
     # Default to false unless explicitly set to true.
     options.forceStartup = false unless options.forceStartup is true
-
-    if trailingSlash.test route.path
-      if @settings.trailing is no
-        route.path = route.path.replace trailingSlash, '$2'
-    else
-      if @settings.trailing is yes
-        route.path += '/'
 
     # Stop if the desired controller/action is already active
     # with the same params.

--- a/src/chaplin/lib/router.coffee
+++ b/src/chaplin/lib/router.coffee
@@ -25,6 +25,7 @@ module.exports = class Router # This class does not extend Backbone.Router.
     _.defaults @options,
       pushState: isWebFile
       root: '/'
+      trailing: no
 
     # Cached regex for stripping a leading subdir and hash/slash.
     @removeRoot = new RegExp('^' + utils.escapeRegExp(@options.root) + '(#)?')
@@ -83,6 +84,10 @@ module.exports = class Router # This class does not extend Backbone.Router.
           'options.controller / options.action'
       # Separate target into controller and controller action.
       [controller, action] = target.split('#')
+
+    # Let each match call provide its own trailing option to appropriate Route.
+    # Pass trailing value from the Router by default.
+    _.defaults options, trailing: @options.trailing
 
     # Create the route.
     route = new Route pattern, controller, action, options

--- a/test/spec/dispatcher_spec.coffee
+++ b/test/spec/dispatcher_spec.coffee
@@ -98,56 +98,6 @@ define [
 
     # The Tests
 
-    it 'should add the trailing slash to route path', (done) ->
-      controllerLoaded = sinon.spy dispatcher, 'controllerLoaded'
-      dispatcher.settings.trailing = yes
-
-      publishMatch route1, params, options
-
-      loadTest1Controller ->
-        [passedRoute] = controllerLoaded.firstCall.args
-
-        expect(controllerLoaded).was.calledOnce()
-        expect(passedRoute.path).to.match /\/$/
-
-        controllerLoaded.restore()
-
-        done()
-
-    it 'should remove the trailing slash from route path', (done) ->
-      controllerLoaded = sinon.spy dispatcher, 'controllerLoaded'
-      dispatcher.settings.trailing = no
-
-      route1.path += '/'
-      publishMatch route1, params, options
-
-      loadTest1Controller ->
-        [passedRoute] = controllerLoaded.firstCall.args
-
-        expect(controllerLoaded).was.calledOnce()
-        expect(passedRoute.path).not.to.match /\/$/
-
-        controllerLoaded.restore()
-
-        done()
-
-    it 'should leave the trailing slash in the route path', (done) ->
-      controllerLoaded = sinon.spy dispatcher, 'controllerLoaded'
-      dispatcher.settings.trailing = null
-
-      route1.path += '/'
-      publishMatch route1, params, options
-
-      loadTest1Controller ->
-        [passedRoute] = controllerLoaded.firstCall.args
-
-        expect(controllerLoaded).was.calledOnce()
-        expect(passedRoute.path).to.match /\/$/
-
-        controllerLoaded.restore()
-
-        done()
-
     it 'should dispatch routes to controller actions', (done) ->
       proto = Test1Controller.prototype
       initialize = sinon.spy proto, 'initialize'

--- a/test/spec/router_spec.coffee
+++ b/test/spec/router_spec.coffee
@@ -109,6 +109,21 @@ define [
           router.match 'url', {}
         ).to.throwError()
 
+      it 'should pass trailing option from Router by default', ->
+        url = 'url'
+        target = 'c#a'
+
+        route = router.match url, target
+        expect(route.options.trailing).to.be router.options.trailing
+
+        router.options.trailing = true
+
+        route = router.match url, target
+        expect(route.options.trailing).to.be true
+
+        route = router.match url, target, trailing: null
+        expect(route.options.trailing).to.be null
+
     describe 'Routing', ->
 
       it 'should fire a router:match event when a route matches', ->
@@ -206,6 +221,39 @@ define [
         expect(passedParams.two).to.be undefined
 
         mediator.unsubscribe 'router:match', spy
+
+      it 'should identically match URLs that differ only by trailing slash', ->
+        router.match 'url', 'null#null'
+
+        routed = router.route url: 'url/'
+        expect(routed).to.be true
+
+        routed = router.route url: 'url/?'
+        expect(routed).to.be true
+
+        routed = router.route url: 'url/?key=val'
+        expect(routed).to.be true
+
+      it 'should leave trailing slash accordingly to current options', ->
+        router.match 'url', 'null#null', trailing: null
+        routed = router.route url: 'url/'
+        expect(routed).to.be true
+        expect(passedRoute).to.be.an 'object'
+        expect(passedRoute.path).to.be 'url/'
+
+      it 'should remove trailing slash accordingly to current options', ->
+        router.match 'url', 'null#null', trailing: false
+        routed = router.route url: 'url/'
+        expect(routed).to.be true
+        expect(passedRoute).to.be.an 'object'
+        expect(passedRoute.path).to.be 'url'
+
+      it 'should add trailing slash accordingly to current options', ->
+        router.match 'url', 'null#null', trailing: true
+        routed = router.route url: 'url'
+        expect(routed).to.be true
+        expect(passedRoute).to.be.an 'object'
+        expect(passedRoute.path).to.be 'url/'
 
     describe 'Passing the Route', ->
 
@@ -439,6 +487,11 @@ define [
         expect(route.reverse one: 1).to.eql false
         expect(route.reverse two: 2).to.eql false
         expect(route.reverse()).to.eql false
+
+      it 'should add trailing slash accordingly to current options', ->
+        route = new Route 'params', 'null', 'null', trailing: true
+        url = route.reverse()
+        expect(url).to.be 'params/'
 
     describe 'Router reversing', ->
       register = ->


### PR DESCRIPTION
Reworked #727. Also made some refactoring and added more tests.

Question. What should we do in the case when you pass a pattern with a trailing slash directly into `Router::match`? IMO, we should truncate the slash internally, so there won't be any difference between ordinary kind of pattern and this one.

Note. If we then decide to change default value for the `trailing` option to `true`, then many tests will fail, because they use hard-coded URLs without slashes for checking result.
