### PR TITLE
Move changeURL command from Dispatcher into Router

### DIFF
--- a/src/chaplin/dispatcher.coffee
+++ b/src/chaplin/dispatcher.coffee
@@ -60,10 +60,6 @@ module.exports = class Dispatcher
     # null or undefined query parameters are equivalent to an empty hash
     options.query = {} if not options.query?
 
-    # Whether to update the URL after controller startup.
-    # Default to true unless explicitly set to false.
-    options.changeURL = true unless options.changeURL is false
-
     # Whether to force the controller startup even
     # if current and new controllers and params match
     # Default to false unless explicitly set to true.
@@ -133,9 +129,6 @@ module.exports = class Dispatcher
     # Stop if the action triggered a redirect.
     return if controller.redirected
 
-    # Adjust the URL.
-    @adjustURL route, params, options
-
     # We're done! Spread the word!
     @publishEvent 'dispatcher:dispatch', @currentController,
       params, route, options
@@ -169,14 +162,6 @@ module.exports = class Dispatcher
       promise.then executeAction
     else
       executeAction()
-
-  # Change the URL to the new controller using the router.
-  adjustURL: (route, params, options) ->
-    return unless route.path?
-
-    # Tell the router to actually change the current URL.
-    url = route.path + if route.query then "?#{route.query}" else ""
-    mediator.execute 'router:changeURL', url, options if options.changeURL
 
   # Disposal
   # --------

--- a/src/chaplin/lib/router.coffee
+++ b/src/chaplin/lib/router.coffee
@@ -33,9 +33,10 @@ module.exports = class Router # This class does not extend Backbone.Router.
     @subscribeEvent '!router:routeByName', @oldEventError
     @subscribeEvent '!router:changeURL', @oldURLEventError
 
+    @subscribeEvent 'dispatcher:dispatch', @changeURL
+
     mediator.setHandler 'router:route', @route, this
     mediator.setHandler 'router:reverse', @reverse, this
-    mediator.setHandler 'router:changeURL', @changeURL, this
 
     @createHistory()
 
@@ -44,8 +45,7 @@ module.exports = class Router # This class does not extend Backbone.Router.
   Use `Chaplin.utils.redirectTo`'
 
   oldURLEventError: ->
-    throw new Error '!router:changeURL event was removed.
-  Use mediator.execute("router:changeURL")'
+    throw new Error '!router:changeURL event was removed.'
 
   # Create a Backbone.History instance.
   createHistory: ->
@@ -167,7 +167,11 @@ module.exports = class Router # This class does not extend Backbone.Router.
     throw new Error 'Router#reverse: invalid route specified'
 
   # Change the current URL, add a history entry.
-  changeURL: (url, options = {}) ->
+  changeURL: (controller, params, route, options) ->
+    return unless route.path? and options.changeURL
+
+    url = route.path + if route.query then "?#{route.query}" else ""
+
     navigateOptions =
       # Do not trigger or replace per default.
       trigger: options.trigger is true

--- a/test/spec/dispatcher_spec.coffee
+++ b/test/spec/dispatcher_spec.coffee
@@ -16,7 +16,6 @@ define [
     # Default options which are added on first dispatching
 
     addedOptions =
-      changeURL: true
       forceStartup: false
 
     # Test controllers
@@ -85,7 +84,6 @@ define [
     # Register before/after handlers
 
     beforeEach ->
-      mediator.setHandler 'router:changeURL', ->
       # Create a fresh Dispatcher instance for each test
       dispatcher = new Dispatcher()
       refreshParams()
@@ -94,7 +92,6 @@ define [
       if dispatcher
         dispatcher.dispose()
         dispatcher = null
-      mediator.removeHandlers ['router:changeURL']
 
     # The Tests
 
@@ -391,58 +388,6 @@ define [
           expect(passedOptions).to.eql stdOptions
 
         mediator.unsubscribe 'dispatcher:dispatch', dispatch
-
-        done()
-
-    it 'should adjust the URL and pass route options', (done) ->
-      spy = sinon.spy()
-      mediator.setHandler 'router:changeURL', spy
-
-      path = 'my-little-path'
-      routeA = create route1, {path}
-      options = {}
-      publishMatch routeA, params, options
-
-      loadTest1Controller ->
-        expect(spy).was.calledOnce()
-        [passedPath, passedOptions] = spy.firstCall.args
-        expect(passedPath).to.be path
-        expect(passedOptions).to.eql stdOptions
-
-        mediator.removeHandlers ['router:changeURL']
-
-        done()
-
-    it 'should not adjust the URL if not desired', (done) ->
-      spy = sinon.spy()
-      mediator.setHandler 'router:changeURL', spy
-
-      publishMatch route1, params, changeURL: false
-
-      loadTest1Controller ->
-        expect(spy).was.notCalled()
-
-        mediator.removeHandlers ['router:changeURL']
-
-        done()
-
-    it 'should add the query string when adjusting the URL', (done) ->
-      spy = sinon.spy()
-      mediator.setHandler 'router:changeURL', spy
-
-      path = 'my-little-path'
-      query = 'foo=bar'
-
-      routeB = create route1, {path, query}
-      publishMatch routeB, params, options
-
-      loadTest1Controller ->
-        expect(spy).was.calledOnce()
-        [passedPath, passedOptions]  = spy.firstCall.args
-        expect(passedPath).to.be "#{path}?#{query}"
-        expect(passedOptions).to.eql stdOptions
-
-        mediator.removeHandlers ['router:changeURL']
 
         done()
 

--- a/test/spec/router_spec.coffee
+++ b/test/spec/router_spec.coffee
@@ -640,17 +640,39 @@ define [
       it 'should forward changeURL routing options to Backbone', ->
         path = 'router-changeurl-options'
         changeURL = sinon.spy router, 'changeURL'
-        navigate = sinon.stub Backbone.history, 'navigate'
+        navigate = sinon.spy Backbone.history, 'navigate'
+        options = some: 'stuff', changeURL: true
 
-        options = some: 'stuff'
-        mediator.execute 'router:changeURL', path, options
+        router.changeURL null, null, {path}, options
         expect(navigate).was.calledWith path,
           replace: false, trigger: false
 
-        options = replace: true, trigger: true, some: 'stuff'
-        mediator.execute 'router:changeURL', path, options
-        expect(Backbone.history.navigate).was.calledWith path,
-          replace: true, trigger: true
+        forwarding = replace: true, trigger: true
+        router.changeURL null, null, {path}, create(options, forwarding)
+        expect(navigate).was.calledWith path, forwarding
+
+        changeURL.restore()
+        navigate.restore()
+
+      it 'should not adjust the URL if not desired', ->
+        path = 'router-changeurl-false'
+        changeURL = sinon.spy router, 'changeURL'
+        navigate = sinon.spy Backbone.history, 'navigate'
+
+        router.changeURL null, null, {path}, changeURL: false
+        expect(navigate).was.notCalled()
+
+        changeURL.restore()
+        navigate.restore()
+
+      it 'should add the query string when adjusting the URL', ->
+        path = 'my-little-path'
+        query = 'foo=bar'
+        changeURL = sinon.spy router, 'changeURL'
+        navigate = sinon.spy Backbone.history, 'navigate'
+
+        router.changeURL null, null, {path, query}, changeURL: true
+        expect(navigate).was.calledWith "#{path}?#{query}"
 
         changeURL.restore()
         navigate.restore()


### PR DESCRIPTION
Note. I've deleted `router:changeURL` command at all.

I also think that now we can remove error handlers for old events. We already have 0.12 with them.
