### PR TITLE
Add hint about replacing urls

### DIFF
--- a/docs/chaplin.utils.md
+++ b/docs/chaplin.utils.md
@@ -16,6 +16,10 @@ Does a in-app redirect:
 
 In the past, `!route:route[byName]` event was used for this purpose.
 
+To use replaceState and overwrite the current URL in the history you can use the
+third options arg that is forwarded to Backbone's `router.navigate`, e.g.
+`redirectTo('messages#show', {id: 2}, {replace: true})`
+
 <h3 class="module-member" id="reverse">reverse(routeName[,...params])</h3>
 Returns the URL for a named route, appropriately filling in values given as `params`.
 


### PR DESCRIPTION
Took me a while to dig through source until I realized this was just forwarded to backbone and I could use the replace arg there, so I figured it can't hurt to have it in the docs.

It can be really useful to when manually redirecting to avoid messing up the user's back button.
