### PR TITLE
Add custom routeStripper and rootStripper option for Chaplin.Route.

### DIFF
--- a/src/chaplin/lib/history.coffee
+++ b/src/chaplin/lib/history.coffee
@@ -46,6 +46,8 @@ class History extends Backbone.History
     @_wantsPushState  = Boolean @options.pushState
     @_hasPushState    = Boolean (@options.pushState and @history and @history.pushState)
     fragment          = @getFragment()
+    routeStripper     = @options.routeStripper ? routeStripper
+    rootStripper      = @options.rootStripper ? rootStripper
 
     # Normalize root to always include a leading and trailing slash.
     @root = ('/' + @root + '/').replace rootStripper, '/'


### PR DESCRIPTION
## Why

I need to support hashbang `#!` in Backbone.History, which means I need to make url like `#!user/:user_id/projects` transparently redirect to `user/:user_id/projects` but the default options doesn't include hook for me to pass my custom regex, so I made this pr, please consider it, thanks!
