### PR TITLE
Added route criteria to Router#reverse's "invalid route" error

### DIFF
--- a/src/chaplin/lib/router.coffee
+++ b/src/chaplin/lib/router.coffee
@@ -169,7 +169,7 @@ module.exports = class Router # This class does not extend Backbone.Router.
         return url
 
     # We didn't get anything.
-    throw new Error 'Router#reverse: invalid route specified'
+    throw new Error "Router#reverse: invalid route criteria specified: #{JSON.stringify criteria}"
 
   # Change the current URL, add a history entry.
   changeURL: (controller, params, route, options) ->

--- a/test/spec/router_spec.coffee
+++ b/test/spec/router_spec.coffee
@@ -519,6 +519,10 @@ define [
 
         expect(-> router.reverse 'missing', one: 145).to.throwError()
 
+      it 'should report the given criteria if reversal fails', ->
+        register()
+        expect(-> router.reverse 'missing').to.throwError(/"missing"/)
+
       it 'should allow for reversing a route by its controller', ->
         register()
         url = router.reverse controller: 'null'


### PR DESCRIPTION
Sometimes it's hard to instantly see why Chaplin failed to reverse a route since the error message is not quite helpful. This PR adds the (JSON stringified) criteria to the error message.
