### PR TITLE
Gruntfile references wrong components folder

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -122,7 +122,7 @@ module.exports = (grunt) ->
               version: pkg.version,
               main: 'chaplin.js',
               scripts: ['chaplin.js'],
-              dependencies: { '#{componentsFolder}/backbone': '1.0.0' }
+              dependencies: (obj = {}; obj["#{ componentsFolder }/backbone"] = '1.0.0'; obj)
             }
           },
           {
@@ -317,7 +317,7 @@ module.exports = (grunt) ->
     bower:
       install:
         options:
-          targetDir: './test/'+componentsFolder
+          targetDir: "./test/#{ componentsFolder }"
           cleanup: true
 
     # Test runner

--- a/test/initialize.js
+++ b/test/initialize.js
@@ -13,15 +13,15 @@ var match = window.location.search.match(/type=([-\w]+)/);
 var testType = window.testType || (match ? match[1] : 'backbone');
 
 var addDeps = function() {
-  paths.underscore = '../'+componentsFolder+'/lodash/lodash.compat';
-  paths.jquery = '../'+componentsFolder+'/jquery/jquery';
+  paths.underscore = '../' + componentsFolder + '/lodash/lodash.compat';
+  paths.jquery = '../' + componentsFolder + '/jquery/jquery';
 };
 if (testType === 'backbone') {
-  paths.backbone = '../'+componentsFolder+'/backbone/backbone'
+  paths.backbone = '../' + componentsFolder + '/backbone/backbone'
   addDeps()
 } else {
   if (testType === 'deps') addDeps();
-  paths.backbone = '../'+componentsFolder+'/exoskeleton/exoskeleton'
+  paths.backbone = '../' + componentsFolder + '/exoskeleton/exoskeleton'
 }
 
 var config = {


### PR DESCRIPTION
Replaced all `components` references to `bower_components` (via a variable) in Gruntfile. Also linked all `bower_components` references to a variable in `initialize.js`
