### PR TITLE
Fixing composer issue where it doesn't respect check() always disposes

### DIFF
--- a/src/chaplin/composer.coffee
+++ b/src/chaplin/composer.coffee
@@ -154,7 +154,7 @@ module.exports = class Composer
         composition.dispose()
         delete @compositions[name]
       else
-        composition.stale true
+        composition.stale composition.check composition.options
 
     # Return nothing.
     return


### PR DESCRIPTION
Chaplin's composer is not respecting the check method and is always disposing regardless. Simply using the check method to determine if a composition is stale or not works great for me.

The long form example here: http://docs.chaplinjs.org/chaplin.composer.html  does not work as described before this PR.
