### PR TITLE
use widely supported `compareDocumentPosition` instead of `contains`

### DIFF
--- a/src/chaplin/lib/utils.coffee
+++ b/src/chaplin/lib/utils.coffee
@@ -148,6 +148,12 @@ utils =
 
       params
 
+  # Element Helpers
+  # --------------
+
+  elementContains: (container, elem) ->
+    container.contains elem
+
 # Backwards-compat.
 utils.queryParams = utils.querystring
 

--- a/src/chaplin/views/view.coffee
+++ b/src/chaplin/views/view.coffee
@@ -444,8 +444,9 @@ module.exports = class View extends Backbone.View
     # Attempt to bind this view to its named region.
     mediator.execute 'region:show', @region, this if @region?
 
-    # Automatically append to DOM if the container element is set.
-    if @container and not document.body.contains @el
+    # Automatically append to DOM if the container element is set
+    # and the element is not already in the DOM.
+    if @container and not (document.body.compareDocumentPosition(@el) & Node.DOCUMENT_POSITION_CONTAINED_BY)
       attach this
       # Trigger an event.
       @trigger 'addedToDOM'

--- a/src/chaplin/views/view.coffee
+++ b/src/chaplin/views/view.coffee
@@ -446,7 +446,7 @@ module.exports = class View extends Backbone.View
 
     # Automatically append to DOM if the container element is set
     # and the element is not already in the DOM.
-    if @container and not (document.body.compareDocumentPosition(@el) & Node.DOCUMENT_POSITION_CONTAINED_BY)
+    if @container and not utils.elementContains document.body, @el
       attach this
       # Trigger an event.
       @trigger 'addedToDOM'


### PR DESCRIPTION
...when attaching views.

 `View.prototype.attach` was using the new-ish DOM api, `contains`, which caused Chaplin to completely not work in Firefox 9 and below (to see bug manifest, https://everlane.com in the aforementioned browsers).

I switched that call for the more widely supported `compareDocumentPosition`, which has been written about a number of times (http://ejohn.org/blog/comparing-document-position/, http://www.quirksmode.org/blog/archives/2006/01/contains_for_mo.html) as a superior and more backward compatible way to check containment. Cool!

Yeah, the code is a bit less pretty now (yep, that is a bitwise operator) but I think it is a fair trade off here. I am not opposed to adding a mega comment block explaining what exactly is happening in detail, if need be.