### PR TITLE
output event name for delegateListeners, for better debug

### DIFF
--- a/src/chaplin/views/view.coffee
+++ b/src/chaplin/views/view.coffee
@@ -288,7 +288,7 @@ module.exports = class View extends Backbone.View
           method = this[method]
         if typeof method isnt 'function'
           throw new Error 'View#delegateListeners: ' +
-            "#{method} must be function"
+            "listener for \"#{key}\" must be function"
 
         # Split event name and target.
         [eventName, target] = key.split ' '


### PR DESCRIPTION
So when you forgot to implement a listener method:

```
    listen:
        'addedToDOM':   'someNoneExistingMethod'
```

instead of

```
Uncaught Error: View#delegateListeners: undefined must be function 
```

We saw:

```
Uncaught Error: View#delegateListeners: listener for "addedToDOM" must be function 
```
