### PR TITLE
Allow linking to myapp.com/root/ when using root

### DIFF
--- a/src/chaplin/lib/history.coffee
+++ b/src/chaplin/lib/history.coffee
@@ -104,7 +104,7 @@ class History extends Backbone.History
     @fragment = fragment
 
     # Don't include a trailing slash on the root.
-    if fragment.length is 0 and url isnt '/'
+    if fragment.length is 0 and url isnt '/' and ( url isnt @root or @options.trailing isnt true )
       url = url.slice 0, -1
 
     # If pushState is available, we use it to set the fragment as a real URL.


### PR DESCRIPTION
I could be wrong, no tests except within my app, but it seems like setting a root option for the Router, like `root: "/admin/"`, then linking to `href="/admin/"` within the app, redirects to localhost/admin instead of localhost/admin/. I'm not sure if both of these checks are necessary (could even just do "url isnt root" instead of the current "url isnt '/'") but I wasn't sure if that would cause any chaos for other situations-
