### PR TITLE
#795: allow View::listen to be a function

### DIFF
--- a/src/chaplin/views/view.coffee
+++ b/src/chaplin/views/view.coffee
@@ -281,6 +281,7 @@ module.exports = class View extends Backbone.View
 
     # Walk all `listen` hashes in the prototype chain.
     for version in utils.getAllPropertyVersions this, 'listen'
+      version = version.call this if typeof version is 'function'
       for key, method of version
         # Get the method, ensure it is a function.
         if typeof method isnt 'function'

--- a/test/spec/view_spec.coffee
+++ b/test/spec/view_spec.coffee
@@ -366,6 +366,17 @@ define [
       expect(e.handler).was.calledOnce()
       expect(e.handler).was.calledOn(e)
 
+    it 'should allow "listen" to be passed as a function', ->
+      class E extends TestView
+        listen: ->
+          'test': 'handler'
+        handler: sinon.spy()
+
+      e = new E
+      e.trigger 'test'
+      expect(e.handler).was.calledOnce()
+      expect(e.handler).was.calledOn(e)
+
     it 'should add and return subviews', ->
       expect(view.subview).to.be.a 'function'
 


### PR DESCRIPTION
As I noticed in #795, **both** `events` and `listen` should allow to be defined as functions
