### PR TITLE
Don't double clean on npm test

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,6 @@
   "main": "build/chaplin.js",
   "scripts": {
     "install": "grunt clean build",
-    "test": "grunt clean prepare test"
+    "test": "grunt prepare test"
   }
 }


### PR DESCRIPTION
grunt prepare already runs clean. no need to do it twice
