### PR TITLE
Fixed bug in collection_view.coffee

### DIFF
--- a/src/chaplin/views/collection_view.coffee
+++ b/src/chaplin/views/collection_view.coffee
@@ -46,7 +46,7 @@ endAnimation = do ->
   else
     (elem, duration) ->
       elem.style.transition = "opacity #{(duration / 1000)}s"
-      elem.opacity = 1
+      elem.style.opacity = 1
 
 insertView = do ->
   if $


### PR DESCRIPTION
In function `endAnimation` changed `elem.opacity = 1` to `elem.style.opacity = 1`. Came across this bug when using Exoskeleton without jquery.
