### PR TITLE
Fix navigation on non standard protocols

### DIFF
--- a/src/chaplin/views/layout.coffee
+++ b/src/chaplin/views/layout.coffee
@@ -99,7 +99,7 @@ module.exports = class Layout extends View
   isExternalLink: (link) ->
     link.target is '_blank' or
     link.rel is 'external' or
-    link.protocol not in ['http:', 'https:', 'file:'] or
+    link.protocol not in ['http:', 'https:', location.protocol] or
     link.hostname not in [location.hostname, '']
 
   # Handle all clicks on A elements and try to route them internally.

--- a/src/chaplin/views/layout.coffee
+++ b/src/chaplin/views/layout.coffee
@@ -99,7 +99,7 @@ module.exports = class Layout extends View
   isExternalLink: (link) ->
     link.target is '_blank' or
     link.rel is 'external' or
-    link.protocol not in ['http:', 'https:', location.protocol] or
+    link.protocol not in ['http:', 'https:', ':', location.protocol] or
     link.hostname not in [location.hostname, '']
 
   # Handle all clicks on A elements and try to route them internally.

--- a/src/chaplin/views/layout.coffee
+++ b/src/chaplin/views/layout.coffee
@@ -99,7 +99,7 @@ module.exports = class Layout extends View
   isExternalLink: (link) ->
     link.target is '_blank' or
     link.rel is 'external' or
-    link.protocol not in ['http:', 'https:', ':', location.protocol] or
+    link.protocol not in ['http:', 'https:', ':', 'file:', location.protocol] or
     link.hostname not in [location.hostname, '']
 
   # Handle all clicks on A elements and try to route them internally.


### PR DESCRIPTION
Navigation was broken inside WinRT apps that uses `ms-appx:` protocol