### PR TITLE
Utils.Reverse() can also handle optionals parameters

### DIFF
--- a/src/chaplin/lib/route.coffee
+++ b/src/chaplin/lib/route.coffee
@@ -124,7 +124,8 @@ module.exports = class Route
       # Convert params from array into object.
       paramsHash = {}
       routeParams = @requiredParams.concat @optionalParams
-      for paramName, paramIndex in routeParams
+      for paramIndex in [0..params.length-1] by 1
+        paramName = routeParams[paramIndex]
         paramsHash[paramName] = params[paramIndex]
 
       return false unless @testConstraints paramsHash

--- a/src/chaplin/lib/route.coffee
+++ b/src/chaplin/lib/route.coffee
@@ -123,7 +123,8 @@ module.exports = class Route
 
       # Convert params from array into object.
       paramsHash = {}
-      for paramName, paramIndex in @requiredParams
+      routeParams = @requiredParams.concat @optionalParams
+      for paramName, paramIndex in routeParams
         paramsHash[paramName] = params[paramIndex]
 
       return false unless @testConstraints paramsHash

--- a/test/spec/router_spec.coffee
+++ b/test/spec/router_spec.coffee
@@ -518,12 +518,14 @@ define [
         router.match 'params/:two', 'null#2', name: 'about'
         router.match 'fake/:three', 'fake#2', name: 'about'
         router.match 'phone/:four', 'null#a'
+        router.match 'users/(:one)', 'null#u1'
+        router.match 'users/:one/(:two)', 'null#u2'
 
       it 'should allow for registering routes with a name', ->
         register()
         names = for handler in Backbone.history.handlers
           handler.route.name
-        expect(names).to.eql ['home', 'phonebook', 'about', 'about', 'null#a']
+        expect(names).to.eql ['home', 'phonebook', 'about', 'about', 'null#a', 'null#u1', 'null#u2']
 
       it 'should allow for reversing a route by its default name', ->
         register()
@@ -577,6 +579,18 @@ define [
         params = one: 145
         res = mediator.execute 'router:reverse', 'phonebook', params
         expect(res).to.be '/subdir/phone/145'
+
+      it 'should handle optional paramters', ->
+        register()
+
+        expect(router.reverse 'null#u1').to.be '/users'
+        expect(router.reverse 'null#u1', one: 'param1').to.be '/users/param1'
+        expect(router.reverse 'null#u1', ['param1']).to.be '/users/param1'
+
+        expect(router.reverse 'null#u2', one: 'param1').to.be '/users/param1'
+        expect(router.reverse 'null#u2', ['param1']).to.be '/users/param1'
+        expect(router.reverse 'null#u2', one: 'param1', two: 'param2').to.be '/users/param1/param2'
+        expect(router.reverse 'null#u2', ['param1', 'param2']).to.be '/users/param1/param2'
 
     describe 'Query string extraction', ->
 


### PR DESCRIPTION
This fix allow `Chaplin.utils.reverse()` to handle optional parameters.
For instance, this route:  `match('users(/:group)(/:source)', 'users#show');`

Without this fix, `Chaplin.utils.reverse('users#show', ['organic', 'all']);` will return `'users/'` whereas now it return `'users/organic/all'` as expected.