### PR TITLE
Update grunt-bower-task

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "grunt-contrib-copy": "0.4.x",
     "grunt-contrib-compress": "0.4.x",
     "grunt-contrib-watch": "0.1.4",
-    "grunt-bower-task": "0.3.x",
+    "grunt-bower-task": "0.4.x",
     "grunt-contrib-uglify": "0.2.x",
     "grunt-istanbul": "0.2.x",
     "grunt-urequire": "git://github.com/concordusapps/grunt-urequire",


### PR DESCRIPTION
grunt-bower-task is outdated and make test prepare step fail as there https://travis-ci.org/chaplinjs/chaplin/builds/35756715 #381 

As written there https://github.com/yatskevich/grunt-bower-task/issues/122, to solve the issue we need to update the grunt-bower-task version.
