### PR TITLE
Fix trailing slash on root

### DIFF
--- a/src/chaplin/lib/history.coffee
+++ b/src/chaplin/lib/history.coffee
@@ -104,7 +104,7 @@ class History extends Backbone.History
     @fragment = fragment
 
     # Don't include a trailing slash on the root.
-    if fragment.length is 0 and url isnt '/' and ( url isnt @root or @options.trailing isnt true )
+    if fragment.length is 0 and url isnt @root
       url = url.slice 0, -1
 
     # If pushState is available, we use it to set the fragment as a real URL.


### PR DESCRIPTION
Related to https://github.com/chaplinjs/chaplin/issues/838

I don't know how to add a test without modifing the code as I need to test the internal variable `url` of `History.navigate`

If you want, i can extract the following code in a function so that I would be able to test it.
```
url = @root + fragment
# Don't include a trailing slash on the root.
if fragment.length is 0 and url isnt @root
  url = url.slice 0, -1
```