### PR TITLE
Fix jquery lookup after disposal

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -79,8 +79,8 @@ module.exports = (grunt) ->
     # -----------------
     urequire:
       AMD:
-        bundlePath: 'temp/'
-        outputPath: 'temp/'
+        path: 'src/'
+        dstPath: 'temp/'
 
         options:
           forceOverwriteSources: true
@@ -139,7 +139,7 @@ module.exports = (grunt) ->
               author: 'Chaplin team',
               license: 'MIT',
               bugs: { url: 'https://github.com/chaplinjs/downloads/issues' },
-              dependencies: { backbone: '~1.1.2', underscore: '~1.6.0' }
+              dependencies: { backbone: '~1.1.2', underscore: '~1.6.0', requirejs: '2.1.1' }
             }
           }
         ]

--- a/src/chaplin/dispatcher.coffee
+++ b/src/chaplin/dispatcher.coffee
@@ -2,6 +2,7 @@
 
 _ = require 'underscore'
 Backbone = require 'backbone'
+requirejs = require 'require'
 mediator = require 'chaplin/mediator'
 utils = require 'chaplin/lib/utils'
 EventBroker = require 'chaplin/lib/event_broker'
@@ -80,10 +81,10 @@ module.exports = class Dispatcher
     fileName = name + @settings.controllerSuffix
     moduleName = @settings.controllerPath + fileName
     if define?.amd
-      require [moduleName], handler
+      requirejs [moduleName], handler
     else
       setTimeout =>
-        handler require moduleName
+        handler requirejs(moduleName)
       , 0
 
   # Handler for the controller lazy-loading.

--- a/src/chaplin/views/view.coffee
+++ b/src/chaplin/views/view.coffee
@@ -180,6 +180,17 @@ module.exports = class View extends Backbone.View
     # Render automatically if set by options or instance property.
     @render() if @autoRender
 
+  # Override `Backbone.$`
+  # -------------------------
+
+  # This makes it safer for views to call `@$` after disposal,
+  # which happens fairly often when dealing with async callbacks.
+  $: ->
+    if @disposed
+     return $()
+    else
+      return super
+
   # User input event handling
   # -------------------------
 


### PR DESCRIPTION
Return an empty jQuery object when when calling `$` on an already disposed view. This makes all async funcs called after disposal not break.