### PR TITLE
Allow object to be specified as the controller in a route match statemen...

### DIFF
--- a/src/chaplin/dispatcher.coffee
+++ b/src/chaplin/dispatcher.coffee
@@ -77,6 +77,8 @@ module.exports = class Dispatcher
   # The default implementation uses require() from a AMD module loader
   # like RequireJS to fetch the constructor.
   loadController: (name, handler) ->
+    return handler(name) if _.isObject name
+
     fileName = name + @settings.controllerSuffix
     moduleName = @settings.controllerPath + fileName
     if define?.amd


### PR DESCRIPTION
Very simple change to allow object to be specified as the controller in a route match statement (e.g. `match 'foo', controller: FooController, action: 'show'`), if the object is given it is returned immediately by `loadController` since it is already loaded. If the parameter is anything else the previous behavior applies.  This enables chaplin to work with tools like webpack and browserify where dynamic requires cause problems.
