### PR TITLE
Fixed url params with more than one equal sign (eg base64)

### DIFF
--- a/src/chaplin/lib/utils.coffee
+++ b/src/chaplin/lib/utils.coffee
@@ -125,12 +125,19 @@ utils =
     # Returns a hash with query parameters from a query string
     parse: (queryString) ->
       params = {}
+      qsDelimiter = 0
       return params unless queryString
       queryString = queryString.slice queryString.indexOf('?') + 1
       pairs = queryString.split '&'
+
       for pair in pairs
         continue unless pair.length
-        [field, value] = pair.split '='
+
+        qsDelimiter = pair.indexOf '='
+        if qsDelimiter != -1
+          field = pair.substring(0, qsDelimiter)
+          value  = pair.substring(qsDelimiter + 1)
+
         continue unless field.length
         field = decodeURIComponent field
         value = decodeURIComponent value


### PR DESCRIPTION
If you have an url like this: http://localhost/#user/resetPassword?code=am9zZS5tYXRvKzEwMDB8Knw2QEt2QHeQ==&param2=value2&param3=value3 you obtain that variable "code" has the value "am9zZS5tYXRvKzEwMDB8Knw2QEt2QHeQ" instead of "am9zZS5tYXRvKzEwMDB8Knw2QEt2QHeQ==" because utils.parse do the folling work:
1) take the queryString "code=am9zZS5tYXRvKzEwMDB8Knw2QEt2QHlMeQ==&param2=value2&param3=value3"
2) split by '&' to get all pair-value items string:
code=am9zZS5tYXRvKzEwMDB8Knw2QEt2QHeQ==
param2=value2
param3=value3

3) For each pair-value item, split by '=' to obtain pair value object:
code: am9zZS5tYXRvKzEwMDB8Knw2QEt2QHeQ (ERROR!!, chaplin forgot data for use String.split function searching for '=' character!)
param2=value2
param3=value3