### PR TITLE
Layout: Add a new openWindow method

### DIFF
--- a/src/chaplin/views/layout.coffee
+++ b/src/chaplin/views/layout.coffee
@@ -132,7 +132,7 @@ module.exports = class Layout extends View
       if @settings.openExternalToBlank
         # Open external links normally in a new tab.
         event.preventDefault()
-        window.open href
+        @openWindow href el
       return
 
     # Pass to the router, try to route the path internally.
@@ -141,6 +141,10 @@ module.exports = class Layout extends View
     # Prevent default handling if the URL could be routed.
     event.preventDefault()
     return
+
+    # Handle all browsing context resources
+    openWindow: (href, el) ->
+      window.open href
 
   # Region management
   # -----------------


### PR DESCRIPTION
It is sometimes necessary, to load resources into a new browser context by using special window names or window features (eg. popups etc).

```js
window.open("http://www.michaelsavage.wnd.com", "_system");
```

See: https://developer.mozilla.org/en-US/docs/Web/API/Window/open

Example:

In Apache Cordova, you can prompt the user to select his favorite browser before opening the url, screenshot: (German l10n):

![screenshot](https://cloud.githubusercontent.com/assets/812964/7537222/4dac4d22-f597-11e4-9ca3-64c72ecc3d8f.png)

You can overwrite the `Chaplin.Layout.openWindow` method during bootstrap.