### PR TITLE
Hotfix url array params

### DIFF
--- a/src/chaplin/lib/utils.coffee
+++ b/src/chaplin/lib/utils.coffee
@@ -125,12 +125,19 @@ utils =
     # Returns a hash with query parameters from a query string
     parse: (queryString) ->
       params = {}
+      qsDelimiter = 0
       return params unless queryString
       queryString = queryString.slice queryString.indexOf('?') + 1
       pairs = queryString.split '&'
+
       for pair in pairs
         continue unless pair.length
-        [field, value] = pair.split '='
+
+        qsDelimiter = pair.indexOf '='
+        if qsDelimiter != -1
+          field = pair.substring(0, qsDelimiter)
+          value  = pair.substring(qsDelimiter + 1)
+
         continue unless field.length
         field = decodeURIComponent field
         value = decodeURIComponent value

--- a/src/chaplin/lib/utils.coffee
+++ b/src/chaplin/lib/utils.coffee
@@ -141,6 +141,10 @@ utils =
         continue unless field.length
         field = decodeURIComponent field
         value = decodeURIComponent value
+
+        if field.indexOf('[]') == field.length - 2 && field.length - 2 > -1
+          field = field.substring(0, field.length - 2)
+
         current = params[field]
         if current
           # Handle multiple params with same name:

--- a/src/chaplin/lib/utils.coffee
+++ b/src/chaplin/lib/utils.coffee
@@ -125,26 +125,17 @@ utils =
     # Returns a hash with query parameters from a query string
     parse: (queryString) ->
       params = {}
-      qsDelimiter = 0
       return params unless queryString
       queryString = queryString.slice queryString.indexOf('?') + 1
       pairs = queryString.split '&'
-
       for pair in pairs
         continue unless pair.length
-
-        qsDelimiter = pair.indexOf '='
-        if qsDelimiter != -1
-          field = pair.substring(0, qsDelimiter)
-          value  = pair.substring(qsDelimiter + 1)
-
+        [field, value] = pair.split '='
         continue unless field.length
         field = decodeURIComponent field
         value = decodeURIComponent value
 
-        if field.indexOf('[]') == field.length - 2 && field.length - 2 > -1
-          field = field.substring(0, field.length - 2)
-
+        field = field.substring(0, field.length - 2) if field.indexOf('[]') == field.length - 2 && field.length - 2 > -1
         current = params[field]
         if current
           # Handle multiple params with same name:


### PR DESCRIPTION
Add support for http arrays on query string and maintain consistency between variable names. Example:

1) with chaplin this url: domain.com/?foo=hi&foo=guys&bar=1 will parse to next object: {foo: [hi, guys], bar: 1}

2) same urls using arrays syntax with brackets:  domain.com/?foo[]=hi&foo[]=guys&bar=1 will parse to next object: {"foo[]": [hi, guys], bar: 1}

So, the problem is that chaplin at this moment is not treating array synxtax with brackets at the same way like array syntax in step 1. With this fix, parse object will be the same as step 1: {foo: [hi, guys], bar: 1}

=> Other scenario will be when you want that "foo" variable will be an array on your application but when this variable has only one element then react will think that is not an array because you call the url with only one value but in other request could be two and then the app will not consistence.