### PR TITLE
if not disposed then dispose in removeSubview

### DIFF
--- a/src/chaplin/views/view.coffee
+++ b/src/chaplin/views/view.coffee
@@ -362,7 +362,7 @@ module.exports = class View extends Backbone.View
     return unless name and view and view.dispose
 
     # Dispose the view.
-    view.dispose()
+    view.dispose() if !view.disposed
 
     # Remove the subview from the lists.
     index = utils.indexOf subviews, view


### PR DESCRIPTION
- call dispose on subview only if it is not disposed.
- this is because if subview has it's own dispose implementation and  if it is disposed earlier and assigning new instance back to same subview name causes subview dispose to be called again.

e.g. scenario steps are as follows
Parent View
  - ['subViewName'] = new Sub View 1
  - cancel button in Sub View 1 disposes itself
again
   - ['subViewName'] = new Sub View 1

So main question I've here is, each view dispose() method has a condition if disposed return. Should the inheriting views add similar condition inside their respective dispose() method as well? or should this be done in removeSubview() method?