### PR TITLE
Updates Backbone dep to 1.2.x

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,7 @@
     "expect": "0.2.x",
     "jquery": "1.9.x",
     "lodash": "2.3.x",
-    "backbone": "1.1.x",
+    "backbone": "1.2.x",
     "benchmark": "git://github.com/bestiejs/benchmark.js.git",
     "sinon": "http://sinonjs.org/releases/sinon-1.7.1.js",
     "requirejs": "~2.1.8",

--- a/src/chaplin/models/model.coffee
+++ b/src/chaplin/models/model.coffee
@@ -83,6 +83,8 @@ module.exports = class Model extends Backbone.Model
     # Fire an event to notify associated collections and views.
     @trigger 'dispose', this
 
+    @collection?.remove? @, silent: true
+
     # Unbind all global event handlers.
     @unsubscribeAllEvents()
 


### PR DESCRIPTION
- Updates Chaplin.Model#dispose to remove model from collections to be compatible
  with updates to backbone's internal changes to `_removeReference` on
  collections. (see: jashkenas/backbone@e926394658dc5871e24e56e13d15194ca098a85a)

The issue this is solving is that if we leave the model its collection after dispose it will not have a reference to its `attributes`, which Backbone now makes use of in `Collection#_removeReference`. Open to discussing other options.
