### PR TITLE
Fix bug with double-freezing of Application

### DIFF
--- a/src/chaplin/application.coffee
+++ b/src/chaplin/application.coffee
@@ -124,9 +124,6 @@ module.exports = class Application
     # Mark app as initialized.
     @started = true
 
-    # Freeze the application instance to prevent further changes.
-    Object.freeze? this
-
   # Disposal
   # --------
   disposed: false

--- a/src/chaplin/application.coffee
+++ b/src/chaplin/application.coffee
@@ -124,6 +124,9 @@ module.exports = class Application
     # Mark app as initialized.
     @started = true
 
+    # Seal the application instance to prevent further changes.
+    Object.seal? this
+
   # Disposal
   # --------
   disposed: false

--- a/test/spec/application_spec.coffee
+++ b/test/spec/application_spec.coffee
@@ -75,6 +75,12 @@ define [
       expect(Backbone.History.started).to.be true
       Backbone.history.stop()
 
+    it 'should seal itself with start()', ->
+      app.initRouter()
+      app.start()
+      if Object.isSealed
+        expect(Object.isSealed(app)).to.be true
+
     it 'should throw an error on double-init', ->
       expect(-> (new (getApp false)).initialize()).to.throwError()
       Backbone.history.stop()

--- a/test/spec/application_spec.coffee
+++ b/test/spec/application_spec.coffee
@@ -12,6 +12,7 @@ define [
 
   describe 'Application', ->
     app = null
+    noInitApp = true
 
     getApp = (noInit) ->
       App = if noInit
@@ -20,7 +21,7 @@ define [
         Application
 
     beforeEach ->
-      app = new (getApp true)
+      app = new (getApp noInitApp)
 
     afterEach ->
       app.dispose()
@@ -78,16 +79,22 @@ define [
       expect(-> (new (getApp false)).initialize()).to.throwError()
       Backbone.history.stop()
 
-    it 'should dispose itself correctly', ->
-      expect(app.dispose).to.be.a 'function'
-      app.dispose()
+    context 'on disposal', ->
+      before ->
+        noInitApp = false
+      after ->
+        noInitApp = true
 
-      for prop in ['dispatcher', 'layout', 'router', 'composer']
-        expect(app[prop]).to.be null
+      it 'should dispose itself correctly', ->
+        expect(app.dispose).to.be.a 'function'
+        app.dispose()
 
-      expect(app.disposed).to.be true
-      if Object.isFrozen
-        expect(Object.isFrozen(app)).to.be true
+        for prop in ['dispatcher', 'layout', 'router', 'composer']
+          expect(app[prop].disposed).to.be true
+
+        expect(app.disposed).to.be true
+        if Object.isFrozen
+          expect(Object.isFrozen(app)).to.be true
 
     it 'should be extendable', ->
       expect(Application.extend).to.be.a 'function'


### PR DESCRIPTION
Application was frozen after `start()` called, this leads to exception on attempt to dispose the Application, at that time Application is already frozen so setting `disposed = true` raises TypeError in browser.
The unit tests were updated too, since this use case was never tested correctly. In the old test Application wasn't initialized (not started) before testing its disposal.