### PR TITLE
Fix bug with double-freezing of Application

### DIFF
--- a/src/chaplin/application.coffee
+++ b/src/chaplin/application.coffee
@@ -124,8 +124,8 @@ module.exports = class Application
     # Mark app as initialized.
     @started = true
 
-    # Freeze the application instance to prevent further changes.
-    Object.freeze? this
+    # Seal the application instance to prevent further changes.
+    Object.seal? this
 
   # Disposal
   # --------

--- a/test/spec/application_spec.coffee
+++ b/test/spec/application_spec.coffee
@@ -74,6 +74,12 @@ define [
       expect(Backbone.History.started).to.be true
       Backbone.history.stop()
 
+    it 'should seal itself with start()', ->
+      app.initRouter()
+      app.start()
+      if Object.isSealed
+        expect(Object.isSealed(app)).to.be true
+
     it 'should throw an error on double-init', ->
       expect(-> (new (getApp false)).initialize()).to.throwError()
       Backbone.history.stop()


### PR DESCRIPTION
Application was frozen after `start()` called, this leads to exception on attempt to dispose the Application, at that time Application is already frozen so setting `disposed = true` raises TypeError in browser. Changing freezing to sealing instead.
The unit tests were updated to check if Application is correctly sealed on start.