### PR TITLE
Fix external links detection

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -63,7 +63,7 @@ module.exports = (grunt) ->
           reporter: 'spec'
           require: [
             'coffee-script/register'
-            -> require('jsdom-global')()
+            'jsdom-assign'
             'jquery'
           ]
         src: 'test/*.coffee'

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "grunt-contrib-uglify": "~0.11.1",
     "coffeeify": "~2.0.1",
     "jsdom": "~8.0.2",
-    "jsdom-global": "~1.6.1",
+    "jsdom-assign": "shvaikalesh/jsdom-assign",
     "coffee-script": "1.10.x",
     "mocha": "~2.4.5",
     "sinon": "~1.17.3",

--- a/test/layout_spec.coffee
+++ b/test/layout_spec.coffee
@@ -110,7 +110,7 @@ describe 'Layout', ->
   it 'should not route `rel=external` links', ->
     expectWasNotRouted href: '/foo', rel: 'external'
 
-  it 'should not route `target=blank` links', ->
+  it 'should not route `target=_blank` links', ->
     expectWasNotRouted href: '/foo', target: '_blank'
 
   it 'should not route non-http(s) links', ->


### PR DESCRIPTION
Resolves https://github.com/chaplinjs/chaplin/issues/878.

Handled some edge cases with `target` and iframes.
Removed hardcoded protocols. Now it handles different ports correctly.
Replaced `jsdom-global` with my-own-stuff because `jsdom` fails to resolve some relative links on `about:blank` and `jsdom-global` does not provide a way to set url. `jsdom-assign` provides valid and real-world-like urls, cookies etc. And it works on `require`, w/o closure.