### PR TITLE
Remove the need to install grunt-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,20 +21,19 @@ Our build script compiles the CoffeeScripts and bundles them into one file. To r
 
 1. Download and install [Node.js](http://nodejs.org/).
 2. Open a shell (aka terminal aka command prompt) and type in the commands in the following steps.
-3. Install the Node package for the grunt command line interface globally.
-
-   ```sh
-   sudo npm install -g grunt-cli
-   ```
-
-   On Windows, you can omit the `sudo` command at the beginning.
-
-4. Change into the Chaplin root directory.
-5. Start the build (will install dependencies and build).
+3. Change into the Chaplin root directory.
+4. Install all dependencies
 
    ```
    npm install
    ```
+
+5. Start the build
+
+   ```
+   npm run build install
+   ```
+
 
 This creates these files in `build` dir:
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
   },
   "main": "build/chaplin.js",
   "scripts": {
-    "test": "grunt test && grunt test:jquery"
+    "test": "grunt test && grunt test:jquery",
+    "build": "grunt build"
   },
   "license": "SEE LICENSE IN MIT-LICENSE.txt"
 }


### PR DESCRIPTION
Grunt-cli is an unneeded PITA here, so let's simplify build instructions by using a npm script.