### PR TITLE
Don't overwrite containerMethod

### DIFF
--- a/src/chaplin/views/view.coffee
+++ b/src/chaplin/views/view.coffee
@@ -122,8 +122,6 @@ module.exports = class View extends Backbone.NativeView or Backbone.View
     for key in Object.keys options
       if key in @optionNames
         @[key] = options[key]
-      else if $ and typeof $::[key] is 'function'
-        @containerMethod = key
 
     # Wrap `render` so `attach` is called afterwards.
     # Enclose the original function.

--- a/test/view_spec.coffee
+++ b/test/view_spec.coffee
@@ -121,9 +121,11 @@ describe 'View', ->
     expect(view.el.parentNode).to.equal testbed
 
   it 'should use the given attach method', ->
-    return unless $
-
-    view = new TestView {container: testbed, 'after'}
+    customContainerMethod = (container, el) ->
+      p = container.parentNode
+      p.insertBefore el, container.nextSibling
+    containerMethod = if $ then 'after' else customContainerMethod
+    view = new TestView {container: testbed, containerMethod}
     view.render()
     expect(view.el).to.equal testbed.nextSibling
     expect(view.el.parentNode).to.equal testbed.parentNode


### PR DESCRIPTION
When a view as an option who is named like a jQuery method (for exemple filter), `containerMethod` take this value and the original value for `containerMethod` is lost.

This branch of the code was introduced during #877, @shvaikalesh can you expand on it? 
I assume this is for :

> Handled the case when View is constructed with { 'after' } as an options. Test for this was present but reported incorrectly.

but I've never seen this options in the docs, and test are still ~~green~~ without this branch of code.

Edit: Hadn't seen this failure locally, investigating.