### PR TITLE
Faster travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
 language: node_js
 node_js:
   - '5.5'
-before_install:
-  - npm install grunt-cli -g

--- a/README.md
+++ b/README.md
@@ -55,7 +55,13 @@ How to run the tests:
    npm test
    ```
 
-Furthermore code coverage reports are generated and may be viewed by opening `coverage/index.html` in your browser.
+or alternatively, if you want code coverage reports
+
+   ```
+   npm run coverage
+   ```
+
+Generated code coverage reports may be viewed by opening `coverage/index.html` in your browser.
 
 ![Ending](http://s3.amazonaws.com/imgly_production/3362023/original.jpg)
 

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
   },
   "main": "build/chaplin.js",
   "scripts": {
-    "test": "grunt test && grunt test:jquery && grunt coverage",
+    "test": "grunt test && grunt test:jquery",
+    "coverage": "grunt coverage",
     "build": "grunt build"
   },
   "license": "SEE LICENSE IN MIT-LICENSE.txt"


### PR DESCRIPTION
First commit remove the installation of grunt-cli in travis, it's not needed with npm scripts.

Second one remove the coverage generation in `npm test` to make it a little faster, per @shvaikalesh suggestion, but I'm not totally sold on the docs change.

