### PR TITLE
Fix regression

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -63,6 +63,7 @@ module.exports = (grunt) ->
           reporter: 'spec'
           require: [
             'coffee-script/register'
+            'coffee-coverage/register-istanbul'
             'jsdom-assign'
             -> require.cache[require.resolve 'jquery'] = {}
             'backbone.nativeview'
@@ -74,17 +75,6 @@ module.exports = (grunt) ->
           require: [
             'coffee-script/register'
             'jsdom-assign'
-          ]
-        src: 'test/*.coffee'
-      coverage:
-        options:
-          reporter: 'spec'
-          require: [
-            'coffee-script/register'
-            'coffee-coverage/register-istanbul'
-            'jsdom-assign'
-            -> require.cache[require.resolve 'jquery'] = {}
-            'backbone.nativeview'
           ]
         src: 'test/*.coffee'
 
@@ -305,15 +295,15 @@ module.exports = (grunt) ->
   # =====================
   grunt.registerTask 'docs:publish', ['check:versions:docs', 'transbrute:docs']
 
-  # Aliases
-  # =======
+  # Tests
+  # =====
   grunt.registerTask 'lint', 'coffeelint'
   grunt.registerTask 'test', 'mochaTest:native'
   grunt.registerTask 'test:jquery', 'mochaTest:jquery'
 
   # Coverage
   # ========
-  grunt.registerTask 'coverage', ['mochaTest:coverage', 'makeReport']
+  grunt.registerTask 'coverage', ['mochaTest:native', 'makeReport']
 
   # Building
   # ========

--- a/test/layout_spec.coffee
+++ b/test/layout_spec.coffee
@@ -27,10 +27,11 @@ describe 'Layout', ->
       link.setAttribute key, attrs[key]
     link
 
-  clickAndRemove = (element) ->
-    body.appendChild element
-    element.click()
-    body.removeChild element
+  clickAndRemove = (link) ->
+    icon = link.appendChild document.createElement 'i'
+    body.appendChild link
+    icon.click()
+    body.removeChild link
 
   expectWasRouted = (attrs) ->
     spy = sinon.spy()
@@ -120,6 +121,9 @@ describe 'Layout', ->
     expectWasNotRouted href: 'mailto:a@a.com'
     expectWasNotRouted href: 'javascript:1+1'
     expectWasNotRouted href: 'tel:1488'
+
+  it 'should not route clicks on [download] links', ->
+    expectWasNotRouted href: '/hello.pdf', download: 'hello.pdf'
 
   it 'should not route clicks on external links', ->
     old = window.open


### PR DESCRIPTION
1. Fixed regression introduced in https://github.com/chaplinjs/chaplin/pull/883, added test coverage.
2. Refactored `Layout#openLink`.
3. Added route skipping for links with `download` attribute, added test.
4. Merged `native` and `coverage` tasks in `Gruntfile`.