### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/_includes/modules.md
+++ b/docs/_includes/modules.md
@@ -13,7 +13,7 @@
 * <a href="./chaplin.dispatcher.html" title="Broker between router and controller">Chaplin.Dispatcher</a>
 * <a href="./chaplin.composer.html" title="Handles reuse of views between controller actions">Chaplin.Composer</a>
 * <a href="./chaplin.layout.html" title="Top-level application view">Chaplin.Layout</a>
-* <a href="./chaplin.application.html" title="Application boostrapper">Chaplin.Application</a>
+* <a href="./chaplin.application.html" title="Application bootstrapper">Chaplin.Application</a>
 
 ### MVC
 * <a href="./chaplin.controller.html" title="For initializing models, collections and views">Chaplin.Controller</a>

--- a/docs/chaplin.event_broker.md
+++ b/docs/chaplin.event_broker.md
@@ -10,7 +10,7 @@ The `EventBroker` offers an interface to interact with [Chaplin.mediator](./chap
 <h2 id="methods">Methods</h2>
 
 <h3 class="module-member" id="publishEvent">publishEvent(event, arguments...)</h3>
-Publishes `event` globablly, passing `arguments` along for interested subscribers.
+Publishes `event` globally, passing `arguments` along for interested subscribers.
 
 <h3 class="module-member" id="subscribeEvent">subscribeEvent(event, handler)</h3>
 Subscribes the `handler` to the given `event`. If `handler` already subscribed to `event`, it will be removed as a subscriber and added afresh. This function is like `Chaplin.mediator.subscribe` except it cannot subscribe twice.

--- a/docs/chaplin.view.md
+++ b/docs/chaplin.view.md
@@ -11,7 +11,7 @@ Views may subscribe to global pub/sub and model/collection events in a manner wh
 
 The templating function is provided by `this.getTemplateFunction`. The input data for the template is provided by `this.getTemplateData`. By default, this method just returns an object delegating to the model attributes. Views might override the method to process the raw model data for the view.
 
-In addition to Backbone’s `events` hash and the `delegateEvents` method, Chaplin has the `delegate` method to register user input handlers. The declarative `events` hash doesn’t work well for class hierarchies when several `initialize` methods register their own handlers. The programatic approach of `delegate` solves these problems.
+In addition to Backbone’s `events` hash and the `delegateEvents` method, Chaplin has the `delegate` method to register user input handlers. The declarative `events` hash doesn’t work well for class hierarchies when several `initialize` methods register their own handlers. The programmatic approach of `delegate` solves these problems.
 
 When establishing bindings between view and model, `this.model.on()` should not be used directly. Instead,  Backbone’s built-in methods for handling bindings, such as `this.listenTo(this.model, ...)` should be used, so handlers can be removed automatically on view disposal to prevent memory leakage.
 
@@ -254,7 +254,7 @@ For events affecting the whole view the signature is `delegate(eventType, handle
 this.delegate('click', this.clicked);
 ```
 
-For events only affecting an element or colletion of elements in the view, pass a selector, too, `delegate(eventType, selector, handler)`:
+For events only affecting an element or collection of elements in the view, pass a selector, too, `delegate(eventType, selector, handler)`:
 
 ```coffeescript
 @delegate('click', 'button.confirm', @confirm)
@@ -345,7 +345,7 @@ However the latter case is more flexible, as it leaves it to the controller to d
 
 <h3 class="module-member" id="regions">regions</h3>
 
-A region registration hash that works much like the declarative events hash present in Backbone. Region names are specifyed as keys, region selectors as values. If the region selector is empty (`''`), the view’s own DOM element will be selected.
+A region registration hash that works much like the declarative events hash present in Backbone. Region names are specified as keys, region selectors as values. If the region selector is empty (`''`), the view’s own DOM element will be selected.
 
 The following snippet will register the named regions `sidebar` and `body` and bind them to their respective selectors directly on the prototype:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,7 +21,7 @@ While Backbone is an easy starting point, it provides only basic, low-level patt
 The bootstrapper of the application; an extension point for key parts of the architecture.
 
 ### [Router](./chaplin.router.html)
-Facilitates mapping URLs to controller actions based on a user-defined configuration file. It is responsible for observing and acting upon URL changes. It does no direct action apart from notifiying the dispatcher of such a change however.
+Facilitates mapping URLs to controller actions based on a user-defined configuration file. It is responsible for observing and acting upon URL changes. It does no direct action apart from notifying the dispatcher of such a change however.
 
 #### Routes
 By convention, routes should be declared in a separate module (typically `routes.coffee`). For example:
@@ -58,7 +58,7 @@ A controller is the place where a model and associated views are instantiated.  
 By convention, there is a controller for each application module. A controller may provide several action methods like `index`, `show`, `edit` and so on.  These actions are called by the `Dispatcher` when a route matches.
 
 ### [Model](./chaplin.model.html)
-Holds reference to the data and contains any logic neccessary to retrieve the data from its source and optionally send it back.
+Holds reference to the data and contains any logic necessary to retrieve the data from its source and optionally send it back.
 
 ### [Collection](./chaplin.collection.html)
 A collection of models. Contains logic to provide client-side filtering and sorting of them.


### PR DESCRIPTION
There are small typos in:
- docs/_includes/modules.md
- docs/chaplin.event_broker.md
- docs/chaplin.view.md
- docs/index.md

Fixes:
- Should read `specified` rather than `specifyed`.
- Should read `programmatic` rather than `programatic`.
- Should read `notifying` rather than `notifiying`.
- Should read `necessary` rather than `neccessary`.
- Should read `globally` rather than `globablly`.
- Should read `collection` rather than `colletion`.
- Should read `bootstrapper` rather than `boostrapper`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md